### PR TITLE
feat(tools): add /tools section + security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 next-env.d.ts
 
 .env
+
+# yt-dlp binaries (downloaded by postinstall)
+/bin/yt-dlp
+/bin/yt-dlp-*

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,6 +113,7 @@ Each section header follows the pattern: `{num} — {TITLE}` using the `SectionH
 | Contact       | 04     |
 | Photography   | 05     |
 | Notes / Blog  | 06     |
+| Tools         | 07     |
 
 ---
 
@@ -123,9 +124,9 @@ Each section header follows the pattern: `{num} — {TITLE}` using the `SectionH
 - **Fixed** top bar, `56px` height, cream background with bottom border
 - **Logo**: "MTOSITY" in monospace bold, `0.875rem`, `0.15em` letter-spacing, uppercase
 - **Logo interaction**: Clicking fires confetti (tsparticles) and navigates home
-- **Desktop links**: `About`, `Photos`, `Writing`, `Contact` — monospace 0.75rem, muted color, hover → fg
+- **Desktop links**: `About`, `Photos`, `Writing`, `Tools` — monospace 0.75rem, muted color, hover → fg
 - **Mobile**: Hamburger icon (3 horizontal lines SVG / X close), dropdown overlay
-- **Links**: `{ label: "About", href: "/" }, { label: "Photos", href: "/photography" }, { label: "Writing", href: "/blog" }, { label: "Contact", href: "/#contact" }`
+- **Links**: `{ label: "About", href: "/" }, { label: "Photos", href: "/photography" }, { label: "Writing", href: "/blog" }, { label: "Tools", href: "/tools" }`
 
 ### Hero Section
 
@@ -232,6 +233,88 @@ All content sections sit inside a max-width `1400px` container.
 - **Lazy loading**: IntersectionObserver with 500px rootMargin
 - **Image hover**: `scale(1.03)` with 0.3s ease transition
 - **Lightbox modal**: Blurred cream backdrop (`rgba(242, 239, 232, 0.92)`, `blur(8px)`), image scales up from 0.92, "Close ✕" button in monospace
+
+### Tools (`/tools`)
+
+- **Header**: Section pattern `07 — TOOLS` with horizontal rule and `{n} ITEMS` count chip on the right
+- **Headline**: Crimson Text `clamp(2.5rem, 6vw, 4.75rem)` with italic muted "Built to be useful." accent; followed by an Inter 1.0625rem muted lede (max-width 52ch)
+- **Tool list**: Vertical list of rows with bottom border (light); each row is a `Link` to `/tools/<slug>`
+- **Row layout**: `auto 1fr auto` grid → number (mono 0.75rem muted) | content block | arrow `→`
+- **Row content**: Title (Crimson Text `clamp(1.5rem, 3.5vw, 2.25rem)` 700) + status chip (`● LIVE` / `◐ BETA` / `○ WIP` · year, mono 0.65rem muted), description (1rem muted, max 62ch), tag chips (same `.chip` styling)
+- **Row entrance**: Clip-path wipe from left (`inset(0 100% 0 0)` → `inset(0 0% 0 0)`), 0.8s, ease `[0.65, 0, 0.35, 1]`, staggered 0.08s per row
+- **Row hover**: Background → `var(--accent)` (lime), `padding-left` slides from `1rem` → `1.5rem`, arrow translates `+8px` — all 0.3s ease
+
+### Tool — Image Grid (`/tools/img-grid`)
+
+- **Layout**: Full-bleed two-column workspace (288px sidebar + flex canvas), with a thin top header strip carrying the crumbs (`← All tools`, `07.03 — TOOL`, `CANVAS · 100% CLIENT-SIDE`) and the title row
+- **Title row**: "Image *grid.*" (Crimson Text `clamp(1.85rem, 4.5vw, 2.75rem)` 700, italic muted accent) + a mono tagline on the right ("Drop images → choose a layout → pan / zoom each tile → export PNG.")
+- **Sidebar (`288px`, cream)**: Each control wrapped in a `Section` with mono 0.65rem 700 uppercase muted label
+  - **Image count / Aspect ratio / Gap / Export size**: Connected pill row (no gap; 1px outer border, internal 1px dividers). Active segment fills lime, inactive segments hover to `var(--bg-secondary)` and `var(--fg)` text
+  - **Layout**: Wrap-grid of mini layout previews — 52px wide thumbnails with the layout's blocks rendered as muted/lime rectangles inside; active card border + bg flip to lime
+  - **Radius**: Native range slider, accent `var(--fg)`, label shows live px
+  - **Background**: Inline color picker chip (28×28, 1px black border) + mono uppercase hex readout in a bordered strip
+  - **Export button** (sticks to bottom via `margin-top: auto`): Mono 0.78rem 700 uppercase. Lime + 4px hard offset shadow when ready, gray + no shadow when blocked. Hover lifts via `translate(-2px, -2px)` with the shadow growing to `6px 6px`. Disabled label shows remaining count: `Fill 2 more`
+- **Canvas pane**: `var(--bg-secondary)` background with a left 1px black rule. Centers a fixed-aspect canvas with `8px 8px 0 var(--border)` hard-offset shadow. Canvas dimensions recompute via `ResizeObserver` whenever the aspect ratio changes (200ms transition on width/height)
+- **Image block**:
+  - Empty state: cream-secondary fill with a 1px dashed border-light outline; centered `+` icon and mono "CLICK OR DROP" label
+  - Hover (empty): outline upgrades to dashed black
+  - Hover (filled): outline upgrades to 2px solid lime
+  - Drag-over: outline becomes 2px dashed black
+  - Filled: image positioned via `cover` math identical to `useImageCombiner.exportImage` so preview matches export pixel-for-pixel
+  - Hover overlay (filled): semi-opaque dark veil (`rgba(13,13,13,0.35)`) with two button rows — `Replace` / `Remove` (mono uppercase, 1px black borders; Remove tinted muted-red) and zoom controls `[−] NNN% [+]` (28px square buttons)
+- **Interactions**:
+  - Click empty block → file picker
+  - Drop file on block → upload (drag/drop highlight)
+  - Mouse drag on filled block → pan, clamped to keep image covering tile
+  - Wheel on filled block → zoom (1x → 5x clamp); zooming out clamps offsets back into range
+  - Replacing or counting up/down auto-revokes Object URLs to avoid leaks
+- **Mobile (<768px)**: Workspace flips to vertical (sidebar above canvas, max 50vh), `CANVAS · 100% CLIENT-SIDE` label and tagline hide
+- **Export pipeline**: `exportImage()` mirrors the CSS preview math on a single `<canvas>`. Block sizes use the same `gap.value / 600 * baseSize` and `borderRadius / 600 * baseSize` scaling so the rendered PNG matches the on-screen tile geometry. Sources: `crossOrigin = "anonymous"`, then `drawImage` with the cover-region math (offset/scale fed back into `sx/sy/sw/sh`). Output sizes: 1080 / 1440 / 2160 / 4320 px on the longest edge
+
+### Tool — Instagram Reel Extractor (`/tools/instagram`)
+
+- **Crumbs**: `← All tools` link, then sub-section header `07.02 — TOOL` left, `YT-DLP · WHISPER · WASM` right
+- **Title**: "Instagram reels, *extracted.*" — Crimson Text `clamp(2.5rem, 6vw, 4.5rem)` with italic muted accent
+- **URL form**: Mono uppercase label "REEL URL", then a flex strip on `var(--bg-secondary)` with 1px black border + `4px 4px 0` shadow:
+  - Mono input (transparent, no border, 0.9rem)
+  - Lime "→ FETCH" submit button (mono 0.75rem 700, 1px black border) — disables to `var(--border-light)` while loading and shows a spinner; otherwise scale 1.02 / 0.98 hover/tap
+  - Footnote line beneath: "Supports /reel/, /reels/, /p/ and /tv/ links · public posts only"
+- **Error banner**: 1px red border + `3px solid #a83232` left rule on `var(--bg-secondary)` carrying server message in mono
+- **Info card**: Two-column grid (`160px 1fr`, collapses below 600px). Left: 9:16 thumbnail with light border. Right:
+  - Uploader handle (mono 0.65rem uppercase muted)
+  - Title (Crimson Text 1.4rem, 3-line clamp)
+  - Meta chips: duration · `WxH` (mono 0.65rem chips)
+  - Action row: `Download MP4` primary action (cream bg, black border, mono 0.72rem 700) + `Get transcript` accent action (lime bg, black border)
+  - Card has 1px black border + `6px 6px 0` shadow
+- **Stage progress**: While transcribing, four-step ordered list with `StageDot` glyphs:
+  - Pending: hollow square (light border)
+  - Active: lime square with pulsing opacity (1 ↔ 0.3, 1.2s)
+  - Done: solid muted square
+  - Steps: `Downloading audio`, `Decoding audio`, `Loading Whisper model` (with `— NN%` while shards download), `Transcribing`
+- **Transcript section**: Header strip `TRANSCRIPT — [Copy] [.txt] [.srt]` (small bordered mono pill buttons), then a Crimson Text 1.0625rem block on `var(--bg-secondary)` with light border, line-height 1.75, whitespace preserved
+- **Footnote row**: DOWNLOADER / TRANSCRIPTION / STORAGE labels and values
+- **Server pipeline**: `/api/instagram/info` (POST, yt-dlp `--dump-single-json`), `/api/instagram/audio` (GET, `bestaudio[ext=m4a]/bestaudio` streamed inline as `audio/mp4`), `/api/instagram/download` (GET, `mp4/best` streamed as attachment). All run on `nodejs` runtime, gated by `checkRateLimit` (10/h sliding window via Upstash; no-op locally). yt-dlp binary resolved from `./bin/`; `next.config.mjs` declares `outputFileTracingIncludes` for each route so the binary is bundled into the serverless function on Vercel.
+- **Client pipeline**: Audio fetched from `/api/instagram/audio` → `AudioContext({ sampleRate: 16000 }).decodeAudioData` (resamples) → mono downmix → dynamic-import of `@huggingface/transformers` → `pipeline("automatic-speech-recognition", "onnx-community/whisper-base.en", { dtype: { encoder_model: "fp32", decoder_model_merged: "q4" }, device: "wasm" })` with `chunk_length_s: 30`, `stride_length_s: 5`, `return_timestamps: true` for SRT export.
+
+### Tool — Speech to Text (`/tools/speech-to-text`)
+
+- **Crumbs**: `← All tools` link (mono 0.7rem uppercase, light underline)
+- **Sub-section header**: `07.01 — TOOL` left, `ON-DEVICE · WHISPER-BASE.EN` right, with horizontal rule between
+- **Title**: "Speech *to* text." — Crimson Text `clamp(2.5rem, 6vw, 4.5rem)` with italic muted "to"
+- **Recorder card**:
+  - 1px black border on `var(--bg-secondary)` with `6px 6px 0` hard offset shadow
+  - Top meta strip: animated status dot + phase label (left), `MM:SS` elapsed timer (right) — both mono 0.7rem uppercase muted
+  - **Mic button** (150×150 wrapper, 88px circular button visually):
+    - Idle: lime background, black 1px border, mic SVG icon, `6px 6px 0` shadow
+    - Recording: black background with stop-square in lime, gentle scale pulse (1 ↔ 1.04, 1.4s loop), three concentric ring waves expanding outward (1.6s, 0.45s stagger)
+    - Hover/tap: scale 1.04 / 0.96 spring
+  - **Waveform**: 28-bar live FFT visualizer (3px wide bars, 56px tall) — driven by `AnalyserNode.getByteFrequencyData`, animates each bar's `height` per frame; idle bars are static gray
+  - **Status line**: Mono 0.75rem uppercase, errors switch to muted red (`#a83232`)
+  - **Loading bar**: 3px tall, fills `var(--fg)` over `var(--border-light)` track (only during model download)
+- **Transcript panel**: Crimson Text 1.0625rem on `var(--bg)`, light border, 180px min-height. Empty state: italic muted "Your words will land here." Filled state fades up (0.3s)
+- **Transcript actions**: Mono pill buttons (Copy / Clear) with border-color hover transition; Copy briefly swaps to "Copied"
+- **Footnotes row**: Auto-fit grid (220px min) — three labeled facts: MODEL, RUNTIME, PRIVACY (mono 0.65rem labels, mono 0.8rem values)
+- **Stack**: `@huggingface/transformers` v4 + `onnx-community/whisper-base.en` (q8 quantization, WASM device); `MediaRecorder` (audio/webm;codecs=opus) → `AudioContext.decodeAudioData` at 16kHz → Float32 mono → Whisper pipeline. Lazy-loaded on mount via dynamic import
 
 ### Notes (`/notes`)
 
@@ -442,7 +525,14 @@ src/
 │   ├── page.tsx              ← Home page composition
 │   ├── blog/                 ← Blog index + dynamic post routes
 │   ├── notes/page.tsx        ← Sticky notes page (inline styles)
-│   └── photography/page.tsx  ← Photo gallery (inline styles)
+│   ├── photography/page.tsx  ← Photo gallery (inline styles)
+│   ├── tools/                ← Tools index + individual tool routes
+│   │   ├── page.tsx          ← Tools list (lime hover row)
+│   │   ├── speech-to-text/   ← On-device Whisper transcription
+│   │   ├── instagram/        ← Instagram reel → MP4 / audio / transcript
+│   │   └── img-grid/         ← Client-side image-grid combiner (Canvas)
+│   └── api/
+│       └── instagram/        ← yt-dlp-backed info / audio / download routes
 ├── components/
 │   ├── Hero.tsx              ← Full-screen hero with parallax
 │   ├── SlideTabs.tsx         ← Fixed navigation bar
@@ -452,6 +542,11 @@ src/
 │       ├── nav/              ← SideBar, Heading + SCSS
 │       ├── buttons/          ← OutlineButton, StandardButton + SCSS
 │       └── utils/            ← Reveal, SectionHeader + SCSS
-└── data/
-    └── blogPosts.ts          ← Blog post registry
+├── data/
+│   ├── blogPosts.ts          ← Blog post registry
+│   └── tools.ts              ← Tools registry
+└── lib/
+    ├── instagram-url.ts      ← Reel URL parser
+    ├── yt-dlp.ts             ← yt-dlp spawn + stream helpers
+    └── rate-limit.ts         ← Upstash sliding-window limiter
 ```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,21 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ["@huggingface/transformers", "onnxruntime-node", "sharp"],
+  outputFileTracingIncludes: {
+    "/api/instagram/info": ["./bin/**/*"],
+    "/api/instagram/audio": ["./bin/**/*"],
+    "/api/instagram/download": ["./bin/**/*"],
+  },
+  outputFileTracingExcludes: {
+    "*": [
+      "node_modules/@huggingface/**",
+      "node_modules/onnxruntime-node/**",
+      "node_modules/onnxruntime-web/**",
+      "node_modules/onnxruntime-common/**",
+      "node_modules/sharp/**",
+      "node_modules/@img/**",
+    ],
+  },
   images: {
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,9 +2,9 @@
 const nextConfig = {
   serverExternalPackages: ["@huggingface/transformers", "onnxruntime-node", "sharp"],
   outputFileTracingIncludes: {
-    "/api/instagram/info": ["./bin/**/*"],
-    "/api/instagram/audio": ["./bin/**/*"],
-    "/api/instagram/download": ["./bin/**/*"],
+    "/api/instagram/info": ["./bin/yt-dlp-linux-*"],
+    "/api/instagram/audio": ["./bin/yt-dlp-linux-*"],
+    "/api/instagram/download": ["./bin/yt-dlp-linux-*"],
   },
   outputFileTracingExcludes: {
     "*": [

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "upload-gallery": "node scripts/upload-to-blob.js"
+    "upload-gallery": "node scripts/upload-to-blob.js",
+    "postinstall": "node scripts/install-ytdlp.mjs"
   },
   "dependencies": {
+    "@huggingface/transformers": "^4.2.0",
     "@lottiefiles/react-lottie-player": "^3.5.4",
     "@types/prismjs": "^1.26.5",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^1.4.0",
     "@vercel/blob": "^2.0.0",
     "@vercel/functions": "^3.0.0",
@@ -19,7 +23,7 @@
     "exif-reader": "^2.0.2",
     "framer-motion": "^11.9.0",
     "lottie-react": "^2.4.1",
-    "next": "16.0.10",
+    "next": "16.2.4",
     "prismjs": "^1.30.0",
     "react": "^18",
     "react-dom": "^18",
@@ -33,7 +37,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^9.0.0",
-    "eslint-config-next": "16.0.10",
+    "eslint-config-next": "16.2.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "next lint",
     "upload-gallery": "node scripts/upload-to-blob.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@lottiefiles/react-lottie-player':
         specifier: ^3.5.4
         version: 3.6.0(react@18.3.1)
       '@types/prismjs':
         specifier: ^1.26.5
         version: 1.26.5
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.37.0)
+      '@upstash/redis':
+        specifier: ^1.37.0
+        version: 1.37.0
       '@vercel/analytics':
         specifier: ^1.4.0
-        version: 1.6.1(next@16.0.10(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0))(react@18.3.1)
+        version: 1.6.1(next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0))(react@18.3.1)
       '@vercel/blob':
         specifier: ^2.0.0
         version: 2.2.0
@@ -36,8 +45,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next:
-        specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0)
+        specifier: 16.2.4
+        version: 16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0)
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -73,8 +82,8 @@ importers:
         specifier: ^9.0.0
         version: 9.39.1(jiti@1.21.7)
       eslint-config-next:
-        specifier: 16.0.10
-        version: 16.0.10(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+        specifier: 16.2.4
+        version: 16.2.4(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       postcss:
         specifier: ^8
         version: 8.4.47
@@ -91,36 +100,36 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -137,26 +146,32 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -164,8 +179,17 @@ packages:
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -201,6 +225,16 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@huggingface/jinja@0.5.8':
+    resolution: {integrity: sha512-ZdElB7DPS7QQS8ZnFc5RPPtkg+eN11z8AmIZWAyes6pSbwXqiFB/POVevvm01begdSX1ho9Gxln/F6qlQMsuaA==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -509,60 +543,63 @@ packages:
     peerDependencies:
       react: 16 - 19
 
-  '@next/env@16.0.10':
-    resolution: {integrity: sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==}
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/eslint-plugin-next@16.0.10':
-    resolution: {integrity: sha512-b2NlWN70bbPLmfyoLvvidPKWENBYYIe017ZGUpElvQjDytCWgxPJx7L9juxHt0xHvNVA08ZHJdOyhGzon/KJuw==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
-  '@next/swc-darwin-arm64@16.0.10':
-    resolution: {integrity: sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==}
+  '@next/eslint-plugin-next@16.2.4':
+    resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
+
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.0.10':
-    resolution: {integrity: sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
-    resolution: {integrity: sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.0.10':
-    resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.0.10':
-    resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.0.10':
-    resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
-    resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.0.10':
-    resolution: {integrity: sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -671,11 +708,44 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/animejs@3.1.13':
     resolution: {integrity: sha512-yWg9l1z7CAv/TKpty4/vupEh24jDGUZXv4r26StRkpUPQm04ztJaftgpto8vwdFs8SiTq6XfaPKCSI+wjzNMvQ==}
@@ -706,64 +776,179 @@ packages:
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
 
-  '@typescript-eslint/eslint-plugin@8.49.0':
-    resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
+  '@typescript-eslint/eslint-plugin@8.59.2':
+    resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.49.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.59.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.49.0':
-    resolution: {integrity: sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==}
+  '@typescript-eslint/parser@8.59.2':
+    resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.49.0':
-    resolution: {integrity: sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==}
+  '@typescript-eslint/project-service@8.59.2':
+    resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.49.0':
-    resolution: {integrity: sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==}
+  '@typescript-eslint/scope-manager@8.59.2':
+    resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.49.0':
-    resolution: {integrity: sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.49.0':
-    resolution: {integrity: sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==}
+  '@typescript-eslint/tsconfig-utils@8.59.2':
+    resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.49.0':
-    resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.49.0':
-    resolution: {integrity: sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==}
+  '@typescript-eslint/type-utils@8.59.2':
+    resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.49.0':
-    resolution: {integrity: sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==}
+  '@typescript-eslint/types@8.59.2':
+    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.2':
+    resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.49.0':
-    resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
+  '@typescript-eslint/utils@8.59.2':
+    resolution: {integrity: sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.37.0':
+    resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -818,6 +1003,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -841,8 +1030,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-query@5.1.3:
-    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -879,6 +1069,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
@@ -886,8 +1080,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.10.0:
-    resolution: {integrity: sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==}
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -897,26 +1091,39 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.9.5:
-    resolution: {integrity: sha512-D5vIoztZOq1XM54LUdttJVc96ggEsIfju2JBvht06pSzpckp3C7HReun67Bghzrtdsq9XdMGbSSB3v3GhMNmAA==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -924,8 +1131,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -940,8 +1147,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001759:
-    resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1026,9 +1233,14 @@ packages:
       supports-color:
         optional: true
 
-  deep-equal@2.2.3:
-    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
-    engines: {node: '>= 0.4'}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1054,6 +1266,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1068,18 +1283,14 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.267:
-    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  enhanced-resolve@5.17.1:
-    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
-    engines: {node: '>=10.13.0'}
-
-  es-abstract@1.24.0:
-    resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -1090,11 +1301,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-get-iterator@1.1.3:
-    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
-
-  es-iterator-helpers@1.0.19:
-    resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
+  es-iterator-helpers@1.3.2:
+    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
   es-object-atoms@1.1.1:
@@ -1113,6 +1321,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1121,8 +1332,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.0.10:
-    resolution: {integrity: sha512-BxouZUm0I45K4yjOOIzj24nTi0H2cGo0y7xUmk+Po/PYtJXFBYVDS1BguE7t28efXjKdcN0tmiLivxQy//SsZg==}
+  eslint-config-next@16.2.4:
+    resolution: {integrity: sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -1130,11 +1341,11 @@ packages:
       typescript:
         optional: true
 
-  eslint-import-resolver-node@0.3.9:
-    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
-  eslint-import-resolver-typescript@3.6.3:
-    resolution: {integrity: sha512-ud9aw4szY9cCT1EWWdGv1L1XR6hh2PaRWif0j2QjQ0pgTY/69iw+W0Z4qZv5wHahOl8isEr+k/JnyAqNQkLkIA==}
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -1177,20 +1388,20 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-jsx-a11y@6.10.0:
-    resolution: {integrity: sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==}
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-react@7.37.0:
-    resolution: {integrity: sha512-IHBePmfWH5lKhJnJ7WB1V+v/GolbB0rjS8XYVCSQCZKaQCAUhMoVoOEn1Ef8Z8Wf0a7l8KTJvuZg5/e4qrZ6nA==}
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
@@ -1206,6 +1417,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
@@ -1285,6 +1500,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
@@ -1321,6 +1539,10 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1337,8 +1559,8 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.8.1:
-    resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1347,6 +1569,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1364,11 +1590,12 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
-  has-bigints@1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1391,6 +1618,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hermes-estree@0.25.1:
@@ -1422,10 +1653,6 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
-    engines: {node: '>= 0.4'}
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1433,8 +1660,8 @@ packages:
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
-  is-async-function@2.0.0:
-    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
 
   is-bigint@1.1.0:
@@ -1453,8 +1680,8 @@ packages:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
 
-  is-bun-module@1.2.1:
-    resolution: {integrity: sha512-AmidtEM6D6NmUiLOvvU7+IePxjEjOzra2h0pSrsfSAcXwl/83zLLXDByafUJy9k/rKK0pvXMLdwKwGHlX2Ke6Q==}
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -1480,8 +1707,8 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
-  is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
@@ -1539,8 +1766,8 @@ packages:
     resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
     engines: {node: '>= 0.4'}
 
-  is-weakset@2.0.3:
-    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
   isarray@2.0.5:
@@ -1549,8 +1776,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  iterator.prototype@1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -1576,6 +1804,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -1618,6 +1849,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1637,6 +1871,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1649,12 +1887,15 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1665,16 +1906,26 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.0.10:
-    resolution: {integrity: sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -1697,8 +1948,12 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1716,10 +1971,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -1728,8 +1979,8 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  object.entries@1.1.8:
-    resolution: {integrity: sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==}
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
     engines: {node: '>= 0.4'}
 
   object.fromentries@2.0.8:
@@ -1743,6 +1994,19 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1789,6 +2053,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -1797,8 +2065,11 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
@@ -1863,6 +2134,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1918,8 +2193,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  resolve@2.0.0-next.5:
-    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+  resolve@2.0.0-next.6:
+    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
+    engines: {node: '>= 0.4'}
     hasBin: true
 
   retry@0.13.1:
@@ -1930,11 +2206,15 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
   safe-push-apply@1.0.0:
@@ -1953,6 +2233,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -1966,6 +2249,15 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -1995,8 +2287,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2018,15 +2310,22 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  string.prototype.includes@2.0.0:
-    resolution: {integrity: sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==}
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
 
-  string.prototype.matchall@4.0.11:
-    resolution: {integrity: sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==}
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
 
   string.prototype.repeat@1.0.0:
@@ -2083,10 +2382,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tapable@2.2.1:
-    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
-    engines: {node: '>=6'}
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -2102,12 +2397,16 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -2128,6 +2427,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2144,12 +2447,12 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.49.0:
-    resolution: {integrity: sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==}
+  typescript-eslint@8.59.2:
+    resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2160,6 +2463,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -2167,8 +2473,11 @@ packages:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
 
-  update-browserslist-db@1.2.2:
-    resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -2191,8 +2500,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.19:
-    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -2222,72 +2531,72 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@babel/code-frame@7.27.1':
+  '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
+  '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.3.7
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.28.5':
+  '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.27.2':
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.28.5
+      '@babel/compat-data': 7.29.3
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2297,37 +2606,48 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.4':
+  '@babel/helpers@7.29.2':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
-  '@babel/parser@7.28.5':
+  '@babel/parser@7.29.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
-  '@babel/template@7.27.2':
+  '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.29.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.3.7
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.5':
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -2339,7 +2659,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.1(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.1(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
@@ -2385,6 +2715,18 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@huggingface/jinja@0.5.8': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.8
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2396,8 +2738,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -2592,34 +2933,41 @@ snapshots:
       lottie-web: 5.13.0
       react: 18.3.1
 
-  '@next/env@16.0.10': {}
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
-  '@next/eslint-plugin-next@16.0.10':
+  '@next/env@16.2.4': {}
+
+  '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.0.10':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.0.10':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.0.10':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.0.10':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.0.10':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.0.10':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2697,11 +3045,39 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/animejs@3.1.13': {}
 
@@ -2728,100 +3104,172 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/type-utils': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
       eslint: 9.39.1(jiti@1.21.7)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.3.7
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
       eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.49.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.49.0
-      debug: 4.3.7
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.49.0':
+  '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/visitor-keys': 8.49.0
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
 
-  '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.3.7
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      debug: 4.4.3
       eslint: 9.39.1(jiti@1.21.7)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.49.0': {}
+  '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/typescript-estree@8.49.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.3.7
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.49.0':
+  '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
-      '@typescript-eslint/types': 8.49.0
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
 
-  '@vercel/analytics@1.6.1(next@16.0.10(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0))(react@18.3.1)':
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.37.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.37.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.37.0
+
+  '@upstash/redis@1.37.0':
+    dependencies:
+      uncrypto: 0.1.3
+
+  '@vercel/analytics@1.6.1(next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0))(react@18.3.1)':
     optionalDependencies:
-      next: 16.0.10(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0)
+      next: 16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0)
       react: 18.3.1
 
   '@vercel/blob@2.2.0':
@@ -2843,6 +3291,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.17: {}
 
   ajv@6.12.6:
     dependencies:
@@ -2868,9 +3318,7 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-query@5.1.3:
-    dependencies:
-      deep-equal: 2.2.3
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -2879,10 +3327,10 @@ snapshots:
 
   array-includes@3.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
       is-string: 1.1.1
@@ -2890,56 +3338,58 @@ snapshots:
 
   array.prototype.findlast@1.2.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.findlastindex@1.2.6:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
 
   array.prototype.flat@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.flatmap@1.3.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.tosorted@1.1.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-shim-unscopables: 1.1.0
 
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
   ast-types-flow@0.0.8: {}
+
+  async-function@1.0.0: {}
 
   async-retry@1.3.3:
     dependencies:
@@ -2947,45 +3397,54 @@ snapshots:
 
   available-typed-arrays@1.0.7:
     dependencies:
-      possible-typed-array-names: 1.0.0
+      possible-typed-array-names: 1.1.0
 
-  axe-core@4.10.0: {}
+  axe-core@4.11.4: {}
 
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.9.5: {}
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.27: {}
 
   binary-extensions@2.3.0: {}
+
+  boolean@3.2.0: {}
 
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.9.5
-      caniuse-lite: 1.0.30001759
-      electron-to-chromium: 1.5.267
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.2(browserslist@4.28.1)
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
+  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -3001,7 +3460,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001759: {}
+  caniuse-lite@1.0.30001791: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3086,26 +3545,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  deep-equal@2.2.3:
+  debug@4.4.3:
     dependencies:
-      array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
-      es-get-iterator: 1.1.3
-      get-intrinsic: 1.3.0
-      is-arguments: 1.1.1
-      is-array-buffer: 3.0.5
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.4
-      isarray: 2.0.5
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      regexp.prototype.flags: 1.5.4
-      side-channel: 1.1.0
-      which-boxed-primitive: 1.1.1
-      which-collection: 1.0.2
-      which-typed-array: 1.1.19
+      ms: 2.1.3
 
   deep-is@0.1.4: {}
 
@@ -3126,8 +3568,9 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
+
+  detect-node@2.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -3143,21 +3586,16 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.267: {}
+  electron-to-chromium@1.5.349: {}
 
   emoji-regex@9.2.2: {}
 
-  enhanced-resolve@5.17.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-
-  es-abstract@1.24.0:
+  es-abstract@1.24.2:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       data-view-buffer: 1.0.2
       data-view-byte-length: 1.0.2
@@ -3176,7 +3614,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -3194,7 +3632,7 @@ snapshots:
       object.assign: 4.1.7
       own-keys: 1.0.1
       regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.3
+      safe-array-concat: 1.1.4
       safe-push-apply: 1.0.0
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
@@ -3207,40 +3645,30 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
-  es-get-iterator@1.1.3:
+  es-iterator-helpers@1.3.2:
     dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      is-arguments: 1.1.1
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-string: 1.1.1
-      isarray: 2.0.5
-      stop-iteration-iterator: 1.1.0
-
-  es-iterator-helpers@1.0.19:
-    dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-set-tostringtag: 2.1.0
       function-bind: 1.1.2
       get-intrinsic: 1.3.0
       globalthis: 1.0.4
+      gopd: 1.2.0
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
       internal-slot: 1.1.0
-      iterator.prototype: 1.1.2
-      safe-array-concat: 1.1.3
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3251,11 +3679,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -3263,22 +3691,24 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es6-error@4.1.1: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.0.10(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.2.4(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.0.10
+      '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.1(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-react: 7.37.0(eslint@9.39.1(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@1.21.7))
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.1(jiti@1.21.7))
       globals: 16.4.0
-      typescript-eslint: 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3287,45 +3717,41 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-import-resolver-node@0.3.9:
+  eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.1
-      resolve: 1.22.11
+      resolve: 2.0.0-next.6
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7
-      enhanced-resolve: 5.17.1
+      debug: 4.4.3
       eslint: 9.39.1(jiti@1.21.7)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7))
-      fast-glob: 3.3.3
-      get-tsconfig: 4.8.1
-      is-bun-module: 1.2.1
-      is-glob: 4.0.3
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3335,12 +3761,12 @@ snapshots:
       debug: 3.2.7
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.39.1(jiti@1.21.7))
-      hasown: 2.0.2
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@1.21.7))
+      hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -3348,63 +3774,62 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.0(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
-      aria-query: 5.1.3
+      aria-query: 5.3.2
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.10.0
+      axe-core: 4.11.4
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.19
       eslint: 9.39.1(jiti@1.21.7)
-      hasown: 2.0.2
+      hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.0
+      string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.3
       eslint: 9.39.1(jiti@1.21.7)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.0(eslint@9.39.1(jiti@1.21.7)):
+  eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@1.21.7)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.3
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
+      es-iterator-helpers: 1.3.2
       eslint: 9.39.1(jiti@1.21.7)
       estraverse: 5.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.8
+      minimatch: 3.1.5
+      object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
       prop-types: 15.8.1
-      resolve: 2.0.0-next.5
+      resolve: 2.0.0-next.6
       semver: 6.3.1
-      string.prototype.matchall: 4.0.11
+      string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
   eslint-scope@8.4.0:
@@ -3415,6 +3840,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.1(jiti@1.21.7):
     dependencies:
@@ -3507,6 +3934,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3524,6 +3955,8 @@ snapshots:
     dependencies:
       flatted: 3.3.1
       keyv: 4.5.4
+
+  flatbuffers@25.9.23: {}
 
   flatted@3.3.1: {}
 
@@ -3545,14 +3978,16 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.3
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3566,7 +4001,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -3580,7 +4015,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.8.1:
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -3591,6 +4026,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.3
+      serialize-error: 7.0.1
 
   globals@14.0.0: {}
 
@@ -3603,9 +4047,9 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  graceful-fs@4.2.11: {}
+  guid-typescript@1.0.9: {}
 
-  has-bigints@1.0.2: {}
+  has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
 
@@ -3624,6 +4068,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -3649,29 +4097,28 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       side-channel: 1.1.0
-
-  is-arguments@1.1.1:
-    dependencies:
-      call-bind: 1.0.8
-      has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
   is-arrayish@0.3.2: {}
 
-  is-async-function@2.0.0:
+  is-async-function@2.1.1:
     dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
       has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-bigint@1.1.0:
     dependencies:
-      has-bigints: 1.0.2
+      has-bigints: 1.1.0
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3684,9 +4131,9 @@ snapshots:
 
   is-buffer@2.0.5: {}
 
-  is-bun-module@1.2.1:
+  is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   is-callable@1.2.7: {}
 
@@ -3711,9 +4158,13 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-generator-function@1.0.10:
+  is-generator-function@1.1.2:
     dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
       has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -3737,7 +4188,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-set@2.0.3: {}
 
@@ -3758,7 +4209,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   is-weakmap@2.0.2: {}
 
@@ -3766,21 +4217,22 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-weakset@2.0.3:
+  is-weakset@2.0.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
-  iterator.prototype@1.1.2:
+  iterator.prototype@1.1.5:
     dependencies:
-      define-properties: 1.2.1
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
+      get-proto: 1.0.1
       has-symbols: 1.1.0
-      reflect.getprototypeof: 1.0.10
       set-function-name: 2.0.2
 
   jiti@1.21.7: {}
@@ -3798,6 +4250,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
     dependencies:
@@ -3837,6 +4291,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -3855,6 +4311,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -3864,13 +4324,17 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@9.0.5:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
 
@@ -3882,28 +4346,33 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.12: {}
+
   nanoid@3.3.7: {}
+
+  napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
 
-  next@16.0.10(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0):
+  next@16.2.4(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.96.0):
     dependencies:
-      '@next/env': 16.0.10
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001759
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.0.10
-      '@next/swc-darwin-x64': 16.0.10
-      '@next/swc-linux-arm64-gnu': 16.0.10
-      '@next/swc-linux-arm64-musl': 16.0.10
-      '@next/swc-linux-x64-gnu': 16.0.10
-      '@next/swc-linux-x64-musl': 16.0.10
-      '@next/swc-win32-arm64-msvc': 16.0.10
-      '@next/swc-win32-x64-msvc': 16.0.10
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       sass: 1.96.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -3913,7 +4382,14 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
-  node-releases@2.0.27: {}
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
+
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
@@ -3923,47 +4399,62 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  object.entries@1.1.8:
+  object.entries@1.1.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   object.fromentries@2.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
 
   object.groupby@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
 
   object.values@1.2.1:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.5.6
 
   optionator@0.9.4:
     dependencies:
@@ -4006,11 +4497,15 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
 
-  possible-typed-array-names@1.0.0: {}
+  platform@1.3.6: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.4.47):
     dependencies:
@@ -4046,7 +4541,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4065,6 +4560,21 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.33
+      long: 5.3.2
 
   punycode@2.3.1: {}
 
@@ -4098,9 +4608,9 @@ snapshots:
 
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -4109,7 +4619,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -4126,9 +4636,12 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  resolve@2.0.0-next.5:
+  resolve@2.0.0-next.6:
     dependencies:
+      es-errors: 1.3.0
       is-core-module: 2.16.1
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -4136,13 +4649,22 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-array-concat@1.1.3:
+  safe-array-concat@1.1.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
@@ -4171,11 +4693,19 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  semver-compare@1.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.6.3: {}
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   set-function-length@1.2.2:
     dependencies:
@@ -4255,7 +4785,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -4263,7 +4792,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -4287,7 +4816,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -4297,21 +4826,27 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  sprintf-js@1.1.3: {}
+
+  stable-hash@0.0.5: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  string.prototype.includes@2.0.0:
+  string.prototype.includes@2.0.1:
     dependencies:
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
 
-  string.prototype.matchall@4.0.11:
+  string.prototype.matchall@4.0.12:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -4325,28 +4860,28 @@ snapshots:
   string.prototype.repeat@1.0.0:
     dependencies:
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.0
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -4354,12 +4889,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -4405,8 +4940,6 @@ snapshots:
       - tsx
       - yaml
 
-  tapable@2.2.1: {}
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -4422,11 +4955,16 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.1.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
@@ -4447,6 +4985,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.13.1: {}
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -4455,7 +4995,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -4464,7 +5004,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -4473,19 +5013,19 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
-      possible-typed-array-names: 1.0.0
+      possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3):
+  typescript-eslint@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.1(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.1(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4496,17 +5036,43 @@ snapshots:
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
-      has-bigints: 1.0.2
+      has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 
   undici@6.23.0: {}
 
-  update-browserslist-db@1.2.2(browserslist@4.28.1):
+  unrs-resolver@1.11.1:
     dependencies:
-      browserslist: 4.28.1
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -4529,28 +5095,28 @@ snapshots:
       call-bound: 1.0.4
       function.prototype.name: 1.1.8
       has-tostringtag: 1.0.2
-      is-async-function: 2.0.0
+      is-async-function: 2.1.1
       is-date-object: 1.1.0
       is-finalizationregistry: 1.1.1
-      is-generator-function: 1.0.10
+      is-generator-function: 1.1.2
       is-regex: 1.2.1
       is-weakref: 1.1.1
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.19
+      which-typed-array: 1.1.20
 
   which-collection@1.0.2:
     dependencies:
       is-map: 2.0.3
       is-set: 2.0.3
       is-weakmap: 2.0.2
-      is-weakset: 2.0.3
+      is-weakset: 2.0.4
 
-  which-typed-array@1.1.19:
+  which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1
@@ -4570,8 +5136,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.1.13
+      zod: 4.4.3
 
-  zod@4.1.13: {}
+  zod@4.4.3: {}

--- a/scripts/install-ytdlp.mjs
+++ b/scripts/install-ytdlp.mjs
@@ -1,0 +1,81 @@
+// Downloads yt-dlp binaries for local dev + both Linux architectures (used on Vercel).
+// Runs via `postinstall`.
+//
+// Layout produced in ./bin/:
+//   yt-dlp                 (local platform-native: macOS/Windows/Linux)
+//   yt-dlp-linux-x64       (Vercel x86_64 runtime)
+//   yt-dlp-linux-arm64     (Vercel Graviton runtime)
+//
+// lib/ytdlp.ts picks the right one at runtime.
+import { createWriteStream, existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import path from "node:path";
+
+const BASE = "https://github.com/yt-dlp/yt-dlp/releases/latest/download";
+
+const PLATFORM_BIN = {
+  linux: "yt-dlp_linux",
+  darwin: "yt-dlp_macos",
+  win32: "yt-dlp.exe",
+};
+
+const LINUX_ARCH_BIN = {
+  x64: "yt-dlp_linux",
+  arm64: "yt-dlp_linux_aarch64",
+};
+
+const BIN_DIR = path.join(process.cwd(), "bin");
+if (!existsSync(BIN_DIR)) mkdirSync(BIN_DIR, { recursive: true });
+
+async function download(filename, dest) {
+  const url = `${BASE}/${filename}`;
+  console.log(`Downloading ${filename} -> ${dest}`);
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok || !res.body) {
+    throw new Error(`HTTP ${res.status} fetching ${url}`);
+  }
+  await pipeline(Readable.fromWeb(res.body), createWriteStream(dest));
+  if (process.platform !== "win32") chmodSync(dest, 0o755);
+  const size = statSync(dest).size;
+  console.log(`  wrote ${size} bytes`);
+  if (size < 1_000_000) {
+    throw new Error(`Downloaded ${filename} too small (${size} bytes); likely a redirect HTML page.`);
+  }
+}
+
+async function ensurePlatformBinary() {
+  const localName = process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
+  const target = path.join(BIN_DIR, localName);
+  if (existsSync(target)) return;
+  const remote = PLATFORM_BIN[process.platform];
+  if (!remote) {
+    console.warn(`Unsupported local platform ${process.platform}; skipping local binary.`);
+    return;
+  }
+  await download(remote, target);
+}
+
+async function ensureVercelBinaries() {
+  // On Vercel builds, the runtime architecture may differ from build-time (Graviton/ARM64).
+  // Download both so we can pick at runtime.
+  if (!process.env.VERCEL && process.platform !== "linux") return;
+  for (const [arch, remote] of Object.entries(LINUX_ARCH_BIN)) {
+    const target = path.join(BIN_DIR, `yt-dlp-linux-${arch}`);
+    if (existsSync(target)) {
+      console.log(`Already present: ${target}`);
+      continue;
+    }
+    await download(remote, target);
+  }
+}
+
+async function main() {
+  await ensurePlatformBinary();
+  await ensureVercelBinaries();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/instagram/audio/route.ts
+++ b/src/app/api/instagram/audio/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { streamYtDlp } from "@/lib/yt-dlp";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { parseInstagramUrl } from "@/lib/instagram-url";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get("url");
+  const ref = url ? parseInstagramUrl(url) : null;
+  if (!url || !ref) {
+    return NextResponse.json({ error: "Invalid Instagram URL" }, { status: 400 });
+  }
+
+  const rl = await checkRateLimit(req);
+  if (!rl.success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Try again later." },
+      { status: 429 },
+    );
+  }
+
+  // Prefer m4a (AAC) — decodable by browser AudioContext without ffmpeg.
+  const stream = streamYtDlp(["-f", "bestaudio[ext=m4a]/bestaudio", url]);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "audio/mp4",
+      "Content-Disposition": `inline; filename="reel-${ref.shortcode}.m4a"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/instagram/download/route.ts
+++ b/src/app/api/instagram/download/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { streamYtDlp } from "@/lib/yt-dlp";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { parseInstagramUrl } from "@/lib/instagram-url";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get("url");
+  const ref = url ? parseInstagramUrl(url) : null;
+  if (!url || !ref) {
+    return NextResponse.json({ error: "Invalid Instagram URL" }, { status: 400 });
+  }
+
+  const rl = await checkRateLimit(req);
+  if (!rl.success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Try again later." },
+      { status: 429 },
+    );
+  }
+
+  const stream = streamYtDlp(["-f", "mp4/best[ext=mp4]/best", url]);
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "video/mp4",
+      "Content-Disposition": `attachment; filename="reel-${ref.shortcode}.mp4"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/instagram/info/route.ts
+++ b/src/app/api/instagram/info/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getInfo, hasCookies } from "@/lib/yt-dlp";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { parseInstagramUrl } from "@/lib/instagram-url";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function POST(req: NextRequest) {
+  const { url } = (await req.json().catch(() => ({}))) as { url?: string };
+  if (!url || !parseInstagramUrl(url)) {
+    return NextResponse.json({ error: "Invalid Instagram URL" }, { status: 400 });
+  }
+
+  const rl = await checkRateLimit(req);
+  if (!rl.success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Try again later." },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil((rl.reset - Date.now()) / 1000)),
+        },
+      },
+    );
+  }
+
+  try {
+    const info = await getInfo(url);
+    return NextResponse.json({
+      title: info.title ?? info.description ?? "Untitled",
+      thumbnail: info.thumbnail ?? null,
+      duration: info.duration ?? null,
+      uploader: info.uploader ?? info.channel ?? null,
+      width: info.width ?? null,
+      height: info.height ?? null,
+    });
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : "Failed to read reel";
+    const blocked =
+      /rate-limit|login required|requested content is not available|cookies/i.test(
+        raw,
+      );
+    const message = blocked
+      ? hasCookies()
+        ? "Instagram blocked this request even with cookies — they may be expired. Refresh IG_COOKIES_TXT or try a different post."
+        : "Instagram requires authentication to view this reel. Set IG_COOKIES_TXT (Netscape cookies.txt) or IG_COOKIES_PATH on the server. See https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp"
+      : raw;
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/instagram/thumb/route.ts
+++ b/src/app/api/instagram/thumb/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+const ALLOWED_HOSTS = [
+  ".cdninstagram.com",
+  ".fbcdn.net",
+  ".instagram.com",
+];
+
+export async function GET(req: NextRequest) {
+  const target = req.nextUrl.searchParams.get("url");
+  if (!target) {
+    return NextResponse.json({ error: "Missing url" }, { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return NextResponse.json({ error: "Invalid url" }, { status: 400 });
+  }
+
+  if (parsed.protocol !== "https:") {
+    return NextResponse.json({ error: "Only https allowed" }, { status: 400 });
+  }
+
+  const host = parsed.hostname;
+  if (!ALLOWED_HOSTS.some((suffix) => host === suffix.slice(1) || host.endsWith(suffix))) {
+    return NextResponse.json({ error: "Host not allowed" }, { status: 400 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(parsed.toString(), {
+      // No Referer / no Origin so Instagram's CDN serves the image
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+      },
+      cache: "no-store",
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "fetch failed";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return NextResponse.json(
+      { error: `Upstream ${upstream.status}` },
+      { status: 502 },
+    );
+  }
+
+  const contentType = upstream.headers.get("content-type") ?? "image/jpeg";
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { blogPosts } from "@/data/blogPosts";
+import { safeJsonLd } from "@/lib/jsonld";
 
 // Import all the individual blog post components
 import BuildingVideoCallAppPage from "../building-video-call-app/page";
@@ -91,28 +92,28 @@ export default function BlogPost({ params }: { params: { slug: string } }) {
     case "building-video-call-app":
       return (
         <>
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
           <BuildingVideoCallAppPage />
         </>
       );
     case "decoding-happiness":
       return (
         <>
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
           <DecodingHappinessPage />
         </>
       );
     case "react-common-mistakes":
       return (
         <>
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
           <ReactCommonMistakesPage />
         </>
       );
     case "hoa-ky-vay-tien":
       return (
         <>
-          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(jsonLd) }} />
           <HoaKyVayTienPage />
         </>
       );

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,9 +19,10 @@ import { Metadata } from "next";
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const post = blogPosts.find((post) => post.slug === params.slug);
+  const { slug } = await params;
+  const post = blogPosts.find((post) => post.slug === slug);
 
   if (!post) {
     return { title: "Post Not Found" };
@@ -60,8 +61,13 @@ export async function generateMetadata({
   };
 }
 
-export default function BlogPost({ params }: { params: { slug: string } }) {
-  const post = blogPosts.find((post) => post.slug === params.slug);
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = blogPosts.find((post) => post.slug === slug);
 
   if (!post) {
     notFound();
@@ -88,7 +94,7 @@ export default function BlogPost({ params }: { params: { slug: string } }) {
   };
 
   // Route to the appropriate component based on slug
-  switch (params.slug) {
+  switch (slug) {
     case "building-video-call-app":
       return (
         <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, Crimson_Text, Lora } from "next/font/google";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
+import { safeJsonLd } from "@/lib/jsonld";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -93,7 +94,7 @@ export default function RootLayout({
         <script src="./sw.js" async={false}></script>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(personJsonLd) }}
         />
       </head>
 

--- a/src/app/tools/img-grid/_components/Canvas.tsx
+++ b/src/app/tools/img-grid/_components/Canvas.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ImageBlock from "./ImageBlock";
+import type { AspectRatio, Layout, Option } from "./layouts";
+import type { ImageState, Transform } from "./useImageCombiner";
+
+type Props = {
+  currentLayout: Layout;
+  aspectRatio: AspectRatio;
+  images: Record<number, ImageState>;
+  onUpload: (i: number, file: File) => void;
+  onRemove: (i: number) => void;
+  onTransform: (i: number, t: Transform) => void;
+  gap: Option<number>;
+  bgColor: string;
+  borderRadius: number;
+};
+
+export default function Canvas({
+  currentLayout,
+  aspectRatio,
+  images,
+  onUpload,
+  onRemove,
+  onTransform,
+  gap,
+  bgColor,
+  borderRadius,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ width: 400, height: 400 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      const rect = el.getBoundingClientRect();
+      const padded = { w: rect.width - 32, h: rect.height - 32 };
+      const ratio = aspectRatio.width / aspectRatio.height;
+
+      let w: number;
+      let h: number;
+      if (padded.w / padded.h > ratio) {
+        h = padded.h;
+        w = h * ratio;
+      } else {
+        w = padded.w;
+        h = w / ratio;
+      }
+      setSize({ width: Math.round(w), height: Math.round(h) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [aspectRatio]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "hidden",
+        minWidth: 0,
+        background: "var(--bg-secondary)",
+        borderLeft: "1px solid var(--border)",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: size.width,
+          height: size.height,
+          backgroundColor: bgColor,
+          borderRadius: borderRadius > 0 ? borderRadius + 2 : 0,
+          transition: "width 0.2s, height 0.2s, background 0.2s",
+        }}
+      >
+        {currentLayout.blocks.map((block, i) => (
+          <ImageBlock
+            key={`${currentLayout.name}-${i}`}
+            index={i}
+            image={images[i]}
+            onUpload={onUpload}
+            onRemove={onRemove}
+            onTransform={onTransform}
+            style={{
+              left: `calc(${block.x * 100}% + ${gap.value / 2}px)`,
+              top: `calc(${block.y * 100}% + ${gap.value / 2}px)`,
+              width: `calc(${block.w * 100}% - ${gap.value}px)`,
+              height: `calc(${block.h * 100}% - ${gap.value}px)`,
+              borderRadius,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/tools/img-grid/_components/ImageBlock.tsx
+++ b/src/app/tools/img-grid/_components/ImageBlock.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import type { ImageState, Transform } from "./useImageCombiner";
+
+type Props = {
+  index: number;
+  image: ImageState | undefined;
+  onUpload: (i: number, file: File) => void;
+  onRemove: (i: number) => void;
+  onTransform: (i: number, t: Transform) => void;
+  style: CSSProperties;
+};
+
+export default function ImageBlock({
+  index,
+  image,
+  onUpload,
+  onRemove,
+  onTransform,
+  style,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const blockRef = useRef<HTMLDivElement | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const dragStart = useRef<
+    | { x: number; y: number; offsetX: number; offsetY: number }
+    | null
+  >(null);
+  const [naturalSize, setNaturalSize] = useState<
+    { width: number; height: number } | null
+  >(null);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) onUpload(index, file);
+    },
+    [index, onUpload],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => setDragOver(false), []);
+
+  const handleClick = useCallback(() => {
+    if (!image) inputRef.current?.click();
+  }, [image]);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onUpload(index, file);
+      e.target.value = "";
+    },
+    [index, onUpload],
+  );
+
+  const handleImgLoad = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      const t = e.currentTarget;
+      setNaturalSize({ width: t.naturalWidth, height: t.naturalHeight });
+    },
+    [],
+  );
+
+  const getImgStyle = (): CSSProperties => {
+    if (!image || !naturalSize || !blockRef.current) return {};
+    const block = blockRef.current.getBoundingClientRect();
+    const bw = block.width;
+    const bh = block.height;
+    if (bw === 0 || bh === 0) return {};
+
+    const imgRatio = naturalSize.width / naturalSize.height;
+    const boxRatio = bw / bh;
+
+    let baseW: number;
+    let baseH: number;
+    if (imgRatio > boxRatio) {
+      baseH = bh;
+      baseW = bh * imgRatio;
+    } else {
+      baseW = bw;
+      baseH = bw / imgRatio;
+    }
+
+    const scale = image.scale || 1;
+    const w = baseW * scale;
+    const h = baseH * scale;
+
+    const maxPanX = (w - bw) / 2;
+    const maxPanY = (h - bh) / 2;
+    const ox = (image.offsetX || 0) * maxPanX;
+    const oy = (image.offsetY || 0) * maxPanY;
+
+    return {
+      width: w,
+      height: h,
+      position: "absolute",
+      left: "50%",
+      top: "50%",
+      transform: `translate(calc(-50% + ${ox}px), calc(-50% + ${oy}px))`,
+      maxWidth: "none",
+      pointerEvents: "none",
+    };
+  };
+
+  const handleWheel = useCallback(
+    (e: WheelEvent) => {
+      if (!image) return;
+      e.preventDefault();
+      const scale = image.scale || 1;
+      const delta = -e.deltaY * 0.002;
+      const newScale = Math.min(5, Math.max(1, scale + delta));
+
+      let offsetX = image.offsetX || 0;
+      let offsetY = image.offsetY || 0;
+      if (newScale < scale) {
+        offsetX = Math.min(1, Math.max(-1, offsetX));
+        offsetY = Math.min(1, Math.max(-1, offsetY));
+      }
+
+      onTransform(index, { scale: newScale, offsetX, offsetY });
+    },
+    [image, index, onTransform],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (!image) return;
+      if ((e.target as HTMLElement).tagName === "BUTTON") return;
+      e.preventDefault();
+      setDragging(true);
+      dragStart.current = {
+        x: e.clientX,
+        y: e.clientY,
+        offsetX: image.offsetX || 0,
+        offsetY: image.offsetY || 0,
+      };
+    },
+    [image],
+  );
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragStart.current || !blockRef.current || !naturalSize) return;
+      const block = blockRef.current.getBoundingClientRect();
+      const bw = block.width;
+      const bh = block.height;
+      const imgRatio = naturalSize.width / naturalSize.height;
+      const boxRatio = bw / bh;
+
+      let baseW: number;
+      let baseH: number;
+      if (imgRatio > boxRatio) {
+        baseH = bh;
+        baseW = bh * imgRatio;
+      } else {
+        baseW = bw;
+        baseH = bw / imgRatio;
+      }
+
+      const scale = image?.scale || 1;
+      const w = baseW * scale;
+      const h = baseH * scale;
+      const maxPanX = (w - bw) / 2;
+      const maxPanY = (h - bh) / 2;
+
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+
+      const newOffsetX =
+        maxPanX > 0
+          ? Math.min(1, Math.max(-1, dragStart.current.offsetX + dx / maxPanX))
+          : 0;
+      const newOffsetY =
+        maxPanY > 0
+          ? Math.min(1, Math.max(-1, dragStart.current.offsetY + dy / maxPanY))
+          : 0;
+
+      onTransform(index, { scale, offsetX: newOffsetX, offsetY: newOffsetY });
+    };
+
+    const handleMouseUp = () => {
+      setDragging(false);
+      dragStart.current = null;
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [dragging, image, index, naturalSize, onTransform]);
+
+  useEffect(() => {
+    const el = blockRef.current;
+    if (!el) return;
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  const outline = dragOver
+    ? "2px dashed var(--fg)"
+    : image
+      ? "1px solid transparent"
+      : "1px dashed var(--border-light)";
+
+  return (
+    <div
+      ref={blockRef}
+      style={{
+        ...style,
+        position: "absolute",
+        overflow: "hidden",
+        outline,
+        outlineOffset: -1,
+        cursor: image ? (dragging ? "grabbing" : "grab") : "pointer",
+        background: image ? "transparent" : "var(--bg-secondary)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transition: "outline-color 0.2s",
+      }}
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onClick={handleClick}
+      onMouseDown={image ? handleMouseDown : undefined}
+      onMouseEnter={(e) => {
+        if (!dragOver && image) {
+          (e.currentTarget as HTMLElement).style.outline = "2px solid var(--accent)";
+        } else if (!dragOver && !image) {
+          (e.currentTarget as HTMLElement).style.outline = "1px dashed var(--fg)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!dragOver) {
+          (e.currentTarget as HTMLElement).style.outline = image
+            ? "1px solid transparent"
+            : "1px dashed var(--border-light)";
+        }
+      }}
+    >
+      {image ? (
+        <>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={image.url}
+            alt=""
+            draggable={false}
+            onLoad={handleImgLoad}
+            style={getImgStyle()}
+          />
+          <div
+            className="ig-controls"
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+              opacity: 0,
+              background: "rgba(13,13,13,0)",
+              transition: "opacity 0.2s, background 0.2s",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.opacity = "1";
+              (e.currentTarget as HTMLElement).style.background =
+                "rgba(13,13,13,0.35)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.opacity = "0";
+              (e.currentTarget as HTMLElement).style.background =
+                "rgba(13,13,13,0)";
+            }}
+          >
+            <div style={{ display: "flex", gap: 6 }}>
+              <OverlayBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  inputRef.current?.click();
+                }}
+              >
+                Replace
+              </OverlayBtn>
+              <OverlayBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove(index);
+                }}
+                tone="danger"
+              >
+                Remove
+              </OverlayBtn>
+            </div>
+            <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+              <SquareBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const scale = image.scale || 1;
+                  onTransform(index, {
+                    scale: Math.max(1, scale - 0.25),
+                    offsetX: image.offsetX,
+                    offsetY: image.offsetY,
+                  });
+                }}
+              >
+                −
+              </SquareBtn>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.7rem",
+                  color: "#fff",
+                  minWidth: "3.2rem",
+                  textAlign: "center",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                {Math.round((image.scale || 1) * 100)}%
+              </span>
+              <SquareBtn
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const scale = image.scale || 1;
+                  onTransform(index, {
+                    scale: Math.min(5, scale + 0.25),
+                    offsetX: image.offsetX,
+                    offsetY: image.offsetY,
+                  });
+                }}
+              >
+                +
+              </SquareBtn>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 8,
+            color: "var(--muted)",
+            pointerEvents: "none",
+          }}
+        >
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 4v16M4 12h16" />
+          </svg>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.65rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+            }}
+          >
+            Click or drop
+          </span>
+        </div>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        style={{ display: "none" }}
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+}
+
+function OverlayBtn({
+  children,
+  onClick,
+  tone = "default",
+}: {
+  children: React.ReactNode;
+  onClick: (e: React.MouseEvent) => void;
+  tone?: "default" | "danger";
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.65rem",
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        fontWeight: 700,
+        background: tone === "danger" ? "rgba(168, 50, 50, 0.85)" : "var(--bg)",
+        color: tone === "danger" ? "#fff" : "var(--fg)",
+        border: "1px solid var(--border)",
+        padding: "0.4rem 0.7rem",
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SquareBtn({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: 28,
+        height: 28,
+        fontFamily: "var(--font-mono)",
+        fontSize: "1rem",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        border: "1px solid var(--border)",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        lineHeight: 1,
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/tools/img-grid/_components/LayoutPreview.tsx
+++ b/src/app/tools/img-grid/_components/LayoutPreview.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { AspectRatio, Layout } from "./layouts";
+
+export default function LayoutPreview({
+  layout,
+  isActive,
+  onClick,
+  aspectRatio,
+}: {
+  layout: Layout;
+  isActive: boolean;
+  onClick: () => void;
+  aspectRatio: AspectRatio;
+}) {
+  const w = 52;
+  const h = Math.round(w * (aspectRatio.height / aspectRatio.width));
+
+  return (
+    <button
+      onClick={onClick}
+      title={layout.name}
+      style={{
+        position: "relative",
+        width: w,
+        height: h,
+        border: `1px solid ${isActive ? "var(--fg)" : "var(--border-light)"}`,
+        background: isActive ? "var(--accent)" : "var(--bg)",
+        cursor: "pointer",
+        flexShrink: 0,
+        padding: 0,
+        transition: "background 0.15s, border-color 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLElement).style.borderColor = "var(--fg)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          (e.currentTarget as HTMLElement).style.borderColor = "var(--border-light)";
+        }
+      }}
+    >
+      {layout.blocks.map((block, i) => (
+        <div
+          key={i}
+          style={{
+            position: "absolute",
+            background: isActive ? "var(--fg)" : "var(--muted)",
+            left: `calc(${block.x * 100}% + 2px)`,
+            top: `calc(${block.y * 100}% + 2px)`,
+            width: `calc(${block.w * 100}% - 4px)`,
+            height: `calc(${block.h * 100}% - 4px)`,
+          }}
+        />
+      ))}
+    </button>
+  );
+}

--- a/src/app/tools/img-grid/_components/Sidebar.tsx
+++ b/src/app/tools/img-grid/_components/Sidebar.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import LayoutPreview from "./LayoutPreview";
+import {
+  ASPECT_RATIOS,
+  EXPORT_SIZES,
+  GAP_OPTIONS,
+  IMAGE_COUNTS,
+  type AspectRatio,
+  type Layout,
+  type Option,
+} from "./layouts";
+import type { ImageState } from "./useImageCombiner";
+
+type Props = {
+  imageCount: number;
+  setImageCount: (n: number) => void;
+  aspectRatio: AspectRatio;
+  setAspectRatio: (a: AspectRatio) => void;
+  layoutIndex: number;
+  setLayoutIndex: (i: number) => void;
+  layouts: Layout[];
+  gap: Option<number>;
+  setGap: (g: Option<number>) => void;
+  exportSize: Option<number>;
+  setExportSize: (s: Option<number>) => void;
+  bgColor: string;
+  setBgColor: (c: string) => void;
+  borderRadius: number;
+  setBorderRadius: (n: number) => void;
+  exportImage: () => void;
+  images: Record<number, ImageState>;
+};
+
+export default function Sidebar({
+  imageCount,
+  setImageCount,
+  aspectRatio,
+  setAspectRatio,
+  layoutIndex,
+  setLayoutIndex,
+  layouts,
+  gap,
+  setGap,
+  exportSize,
+  setExportSize,
+  bgColor,
+  setBgColor,
+  borderRadius,
+  setBorderRadius,
+  exportImage,
+  images,
+}: Props) {
+  const allFilled =
+    Object.keys(images).length === imageCount &&
+    Object.values(images).every(Boolean);
+
+  return (
+    <aside
+      style={{
+        width: 288,
+        flexShrink: 0,
+        background: "var(--bg)",
+        overflowY: "auto",
+        padding: "1.25rem",
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.5rem",
+      }}
+      className="ig-sidebar scrollbar-thin"
+    >
+      <Section title="Images">
+        <Pills
+          options={IMAGE_COUNTS.map((c) => ({ label: String(c), value: c }))}
+          activeValue={imageCount}
+          onChange={(v) => setImageCount(v)}
+        />
+      </Section>
+
+      <Section title="Aspect ratio">
+        <Pills
+          options={ASPECT_RATIOS.map((a) => ({ label: a.label, value: a.value }))}
+          activeValue={aspectRatio.value}
+          onChange={(v) => {
+            const ar = ASPECT_RATIOS.find((a) => a.value === v);
+            if (ar) setAspectRatio(ar);
+          }}
+        />
+      </Section>
+
+      <Section title="Layout">
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {layouts.map((layout, i) => (
+            <LayoutPreview
+              key={`${layout.name}-${i}`}
+              layout={layout}
+              isActive={layoutIndex === i}
+              onClick={() => setLayoutIndex(i)}
+              aspectRatio={aspectRatio}
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Gap">
+        <Pills
+          options={GAP_OPTIONS.map((g) => ({ label: g.label, value: g.value }))}
+          activeValue={gap.value}
+          onChange={(v) => {
+            const g = GAP_OPTIONS.find((o) => o.value === v);
+            if (g) setGap(g);
+          }}
+        />
+      </Section>
+
+      <Section title={`Radius — ${borderRadius}px`}>
+        <input
+          type="range"
+          min={0}
+          max={32}
+          value={borderRadius}
+          onChange={(e) => setBorderRadius(Number(e.target.value))}
+          style={{
+            width: "100%",
+            accentColor: "var(--fg)",
+          }}
+        />
+      </Section>
+
+      <Section title="Background">
+        <div
+          style={{
+            display: "flex",
+            gap: 10,
+            alignItems: "center",
+            border: "1px solid var(--border-light)",
+            padding: "0.5rem 0.6rem",
+          }}
+        >
+          <input
+            type="color"
+            value={bgColor}
+            onChange={(e) => setBgColor(e.target.value)}
+            style={{
+              width: 28,
+              height: 28,
+              border: "1px solid var(--border)",
+              padding: 0,
+              cursor: "pointer",
+              background: "transparent",
+            }}
+          />
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              letterSpacing: "0.08em",
+              color: "var(--fg)",
+              textTransform: "uppercase",
+            }}
+          >
+            {bgColor}
+          </span>
+        </div>
+      </Section>
+
+      <Section title="Export size">
+        <Pills
+          options={EXPORT_SIZES.map((s) => ({ label: s.label, value: s.value }))}
+          activeValue={exportSize.value}
+          onChange={(v) => {
+            const s = EXPORT_SIZES.find((o) => o.value === v);
+            if (s) setExportSize(s);
+          }}
+        />
+      </Section>
+
+      <button
+        onClick={exportImage}
+        disabled={!allFilled}
+        style={{
+          marginTop: "auto",
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.78rem",
+          fontWeight: 700,
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--fg)",
+          background: allFilled ? "var(--accent)" : "var(--border-light)",
+          border: "1px solid var(--border)",
+          padding: "0.95rem",
+          cursor: allFilled ? "pointer" : "not-allowed",
+          boxShadow: allFilled ? "4px 4px 0 var(--border)" : "none",
+          transition: "transform 0.15s, box-shadow 0.15s, background 0.15s",
+        }}
+        onMouseEnter={(e) => {
+          if (!allFilled) return;
+          (e.currentTarget as HTMLElement).style.transform = "translate(-2px, -2px)";
+          (e.currentTarget as HTMLElement).style.boxShadow = "6px 6px 0 var(--border)";
+        }}
+        onMouseLeave={(e) => {
+          if (!allFilled) return;
+          (e.currentTarget as HTMLElement).style.transform = "translate(0, 0)";
+          (e.currentTarget as HTMLElement).style.boxShadow = "4px 4px 0 var(--border)";
+        }}
+      >
+        {allFilled ? "↓ Export PNG" : `Fill ${imageCount - Object.keys(images).length} more`}
+      </button>
+    </aside>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.65rem",
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--muted)",
+          fontWeight: 700,
+          marginBottom: "0.6rem",
+        }}
+      >
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function Pills<T extends string | number>({
+  options,
+  activeValue,
+  onChange,
+}: {
+  options: { label: string; value: T }[];
+  activeValue: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 0,
+        border: "1px solid var(--border-light)",
+      }}
+    >
+      {options.map((o, i) => {
+        const active = o.value === activeValue;
+        return (
+          <button
+            key={String(o.value)}
+            onClick={() => onChange(o.value)}
+            style={{
+              flex: 1,
+              padding: "0.55rem 0.4rem",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              fontWeight: 700,
+              color: active ? "var(--fg)" : "var(--muted)",
+              background: active ? "var(--accent)" : "transparent",
+              border: "none",
+              borderLeft: i === 0 ? "none" : "1px solid var(--border-light)",
+              cursor: "pointer",
+              transition: "background 0.15s, color 0.15s",
+            }}
+            onMouseEnter={(e) => {
+              if (!active) {
+                (e.currentTarget as HTMLElement).style.color = "var(--fg)";
+                (e.currentTarget as HTMLElement).style.background = "var(--bg-secondary)";
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!active) {
+                (e.currentTarget as HTMLElement).style.color = "var(--muted)";
+                (e.currentTarget as HTMLElement).style.background = "transparent";
+              }
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/tools/img-grid/_components/layouts.ts
+++ b/src/app/tools/img-grid/_components/layouts.ts
@@ -1,0 +1,165 @@
+export type AspectRatio = {
+  label: string;
+  value: string;
+  width: number;
+  height: number;
+};
+
+export type Block = { x: number; y: number; w: number; h: number };
+
+export type Layout = { name: string; blocks: Block[] };
+
+export type Option<T> = { label: string; value: T };
+
+export const ASPECT_RATIOS: AspectRatio[] = [
+  { label: "1:1", value: "1/1", width: 1, height: 1 },
+  { label: "4:3", value: "4/3", width: 4, height: 3 },
+  { label: "16:9", value: "16/9", width: 16, height: 9 },
+  { label: "9:16", value: "9/16", width: 9, height: 16 },
+  { label: "3:4", value: "3/4", width: 3, height: 4 },
+];
+
+export function getLayouts(count: number): Layout[] {
+  switch (count) {
+    case 2:
+      return [
+        {
+          name: "Side by side",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 1 },
+            { x: 0.5, y: 0, w: 0.5, h: 1 },
+          ],
+        },
+        {
+          name: "Top and bottom",
+          blocks: [
+            { x: 0, y: 0, w: 1, h: 0.5 },
+            { x: 0, y: 0.5, w: 1, h: 0.5 },
+          ],
+        },
+      ];
+    case 3:
+      return [
+        {
+          name: "1 left + 2 right",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 1 },
+            { x: 0.5, y: 0, w: 0.5, h: 0.5 },
+            { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+          ],
+        },
+        {
+          name: "1 top + 2 bottom",
+          blocks: [
+            { x: 0, y: 0, w: 1, h: 0.5 },
+            { x: 0, y: 0.5, w: 0.5, h: 0.5 },
+            { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+          ],
+        },
+        {
+          name: "3 columns",
+          blocks: [
+            { x: 0, y: 0, w: 1 / 3, h: 1 },
+            { x: 1 / 3, y: 0, w: 1 / 3, h: 1 },
+            { x: 2 / 3, y: 0, w: 1 / 3, h: 1 },
+          ],
+        },
+      ];
+    case 4:
+      return [
+        {
+          name: "2x2 Grid",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 0.5 },
+            { x: 0.5, y: 0, w: 0.5, h: 0.5 },
+            { x: 0, y: 0.5, w: 0.5, h: 0.5 },
+            { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+          ],
+        },
+        {
+          name: "1 left + 3 right",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 1 },
+            { x: 0.5, y: 0, w: 0.5, h: 1 / 3 },
+            { x: 0.5, y: 1 / 3, w: 0.5, h: 1 / 3 },
+            { x: 0.5, y: 2 / 3, w: 0.5, h: 1 / 3 },
+          ],
+        },
+        {
+          name: "4 columns",
+          blocks: [
+            { x: 0, y: 0, w: 0.25, h: 1 },
+            { x: 0.25, y: 0, w: 0.25, h: 1 },
+            { x: 0.5, y: 0, w: 0.25, h: 1 },
+            { x: 0.75, y: 0, w: 0.25, h: 1 },
+          ],
+        },
+      ];
+    case 5:
+      return [
+        {
+          name: "2 top + 3 bottom",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 0.5 },
+            { x: 0.5, y: 0, w: 0.5, h: 0.5 },
+            { x: 0, y: 0.5, w: 1 / 3, h: 0.5 },
+            { x: 1 / 3, y: 0.5, w: 1 / 3, h: 0.5 },
+            { x: 2 / 3, y: 0.5, w: 1 / 3, h: 0.5 },
+          ],
+        },
+        {
+          name: "1 top + 4 bottom",
+          blocks: [
+            { x: 0, y: 0, w: 1, h: 0.5 },
+            { x: 0, y: 0.5, w: 0.25, h: 0.5 },
+            { x: 0.25, y: 0.5, w: 0.25, h: 0.5 },
+            { x: 0.5, y: 0.5, w: 0.25, h: 0.5 },
+            { x: 0.75, y: 0.5, w: 0.25, h: 0.5 },
+          ],
+        },
+      ];
+    case 6:
+      return [
+        {
+          name: "3x2 Grid",
+          blocks: [
+            { x: 0, y: 0, w: 1 / 3, h: 0.5 },
+            { x: 1 / 3, y: 0, w: 1 / 3, h: 0.5 },
+            { x: 2 / 3, y: 0, w: 1 / 3, h: 0.5 },
+            { x: 0, y: 0.5, w: 1 / 3, h: 0.5 },
+            { x: 1 / 3, y: 0.5, w: 1 / 3, h: 0.5 },
+            { x: 2 / 3, y: 0.5, w: 1 / 3, h: 0.5 },
+          ],
+        },
+        {
+          name: "2x3 Grid",
+          blocks: [
+            { x: 0, y: 0, w: 0.5, h: 1 / 3 },
+            { x: 0.5, y: 0, w: 0.5, h: 1 / 3 },
+            { x: 0, y: 1 / 3, w: 0.5, h: 1 / 3 },
+            { x: 0.5, y: 1 / 3, w: 0.5, h: 1 / 3 },
+            { x: 0, y: 2 / 3, w: 0.5, h: 1 / 3 },
+            { x: 0.5, y: 2 / 3, w: 0.5, h: 1 / 3 },
+          ],
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+export const IMAGE_COUNTS = [2, 3, 4, 5, 6];
+
+export const EXPORT_SIZES: Option<number>[] = [
+  { label: "1080", value: 1080 },
+  { label: "1440", value: 1440 },
+  { label: "2160", value: 2160 },
+  { label: "4320", value: 4320 },
+];
+
+export const GAP_OPTIONS: Option<number>[] = [
+  { label: "None", value: 0 },
+  { label: "Sm", value: 8 },
+  { label: "Md", value: 16 },
+  { label: "Lg", value: 24 },
+];

--- a/src/app/tools/img-grid/_components/useImageCombiner.ts
+++ b/src/app/tools/img-grid/_components/useImageCombiner.ts
@@ -1,0 +1,246 @@
+import { useCallback, useState } from "react";
+import {
+  ASPECT_RATIOS,
+  EXPORT_SIZES,
+  GAP_OPTIONS,
+  getLayouts,
+  type AspectRatio,
+  type Option,
+} from "./layouts";
+
+export type ImageState = {
+  url: string;
+  file: File;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+};
+
+export type Transform = Partial<Pick<ImageState, "scale" | "offsetX" | "offsetY">>;
+
+export function useImageCombiner() {
+  const [imageCount, setImageCountRaw] = useState(2);
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>(ASPECT_RATIOS[0]);
+  const [layoutIndex, setLayoutIndex] = useState(0);
+  const [images, setImages] = useState<Record<number, ImageState>>({});
+  const [gap, setGap] = useState<Option<number>>(GAP_OPTIONS[0]);
+  const [exportSize, setExportSize] = useState<Option<number>>(EXPORT_SIZES[0]);
+  const [bgColor, setBgColor] = useState("#0d0d0d");
+  const [borderRadius, setBorderRadius] = useState(0);
+
+  const layouts = getLayouts(imageCount);
+  const currentLayout = layouts[layoutIndex] || layouts[0];
+
+  const setImageCount = useCallback((count: number) => {
+    setImageCountRaw(count);
+    setLayoutIndex(0);
+    setImages((prev) => {
+      Object.values(prev).forEach((img) => URL.revokeObjectURL(img.url));
+      return {};
+    });
+  }, []);
+
+  const handleImageUpload = useCallback((blockIndex: number, file: File) => {
+    if (!file || !file.type.startsWith("image/")) return;
+    const url = URL.createObjectURL(file);
+    setImages((prev) => {
+      const next = { ...prev };
+      if (next[blockIndex]) URL.revokeObjectURL(next[blockIndex].url);
+      next[blockIndex] = { url, file, scale: 1, offsetX: 0, offsetY: 0 };
+      return next;
+    });
+  }, []);
+
+  const handleImageTransform = useCallback(
+    (blockIndex: number, transform: Transform) => {
+      setImages((prev) => {
+        if (!prev[blockIndex]) return prev;
+        return {
+          ...prev,
+          [blockIndex]: { ...prev[blockIndex], ...transform },
+        };
+      });
+    },
+    [],
+  );
+
+  const handleRemoveImage = useCallback((blockIndex: number) => {
+    setImages((prev) => {
+      const next = { ...prev };
+      if (next[blockIndex]) {
+        URL.revokeObjectURL(next[blockIndex].url);
+        delete next[blockIndex];
+      }
+      return next;
+    });
+  }, []);
+
+  const exportImage = useCallback(async () => {
+    const baseSize = exportSize.value;
+    const canvasWidth =
+      aspectRatio.width >= aspectRatio.height
+        ? baseSize
+        : Math.round(baseSize * (aspectRatio.width / aspectRatio.height));
+    const canvasHeight =
+      aspectRatio.height >= aspectRatio.width
+        ? baseSize
+        : Math.round(baseSize * (aspectRatio.height / aspectRatio.width));
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+    const gapPx = Math.round((gap.value / 600) * baseSize);
+    const radiusPx = Math.round((borderRadius / 600) * baseSize);
+
+    const blocks = currentLayout.blocks;
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i];
+      const bx = Math.round(block.x * canvasWidth + gapPx / 2);
+      const by = Math.round(block.y * canvasHeight + gapPx / 2);
+      const bw = Math.round(block.w * canvasWidth - gapPx);
+      const bh = Math.round(block.h * canvasHeight - gapPx);
+
+      if (images[i]) {
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        await new Promise<void>((resolve) => {
+          img.onload = () => resolve();
+          img.src = images[i].url;
+        });
+
+        ctx.save();
+        if (radiusPx > 0) {
+          roundRect(ctx, bx, by, bw, bh, radiusPx);
+          ctx.clip();
+        }
+        const imgData = images[i];
+        drawCover(
+          ctx,
+          img,
+          bx,
+          by,
+          bw,
+          bh,
+          imgData.scale || 1,
+          imgData.offsetX || 0,
+          imgData.offsetY || 0,
+        );
+        ctx.restore();
+      } else {
+        ctx.save();
+        if (radiusPx > 0) {
+          roundRect(ctx, bx, by, bw, bh, radiusPx);
+          ctx.clip();
+        }
+        ctx.fillStyle = "#e8e5dd";
+        ctx.fillRect(bx, by, bw, bh);
+        ctx.restore();
+      }
+    }
+
+    const link = document.createElement("a");
+    link.download = `img-grid-${Date.now()}.png`;
+    link.href = canvas.toDataURL("image/png");
+    link.click();
+  }, [
+    aspectRatio,
+    currentLayout,
+    images,
+    gap,
+    exportSize,
+    bgColor,
+    borderRadius,
+  ]);
+
+  return {
+    imageCount,
+    setImageCount,
+    aspectRatio,
+    setAspectRatio,
+    layoutIndex,
+    setLayoutIndex,
+    layouts,
+    currentLayout,
+    images,
+    handleImageUpload,
+    handleRemoveImage,
+    handleImageTransform,
+    gap,
+    setGap,
+    exportSize,
+    setExportSize,
+    bgColor,
+    setBgColor,
+    borderRadius,
+    setBorderRadius,
+    exportImage,
+  };
+}
+
+function drawCover(
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  scale = 1,
+  offsetX = 0,
+  offsetY = 0,
+) {
+  const imgRatio = img.naturalWidth / img.naturalHeight;
+  const boxRatio = w / h;
+
+  let baseSw: number;
+  let baseSh: number;
+  if (imgRatio > boxRatio) {
+    baseSh = img.naturalHeight;
+    baseSw = baseSh * boxRatio;
+  } else {
+    baseSw = img.naturalWidth;
+    baseSh = baseSw / boxRatio;
+  }
+
+  const sw = baseSw / scale;
+  const sh = baseSh / scale;
+
+  const maxPanX = img.naturalWidth - sw;
+  const maxPanY = img.naturalHeight - sh;
+  const sx = maxPanX / 2 - offsetX * (maxPanX / 2);
+  const sy = maxPanY / 2 - offsetY * (maxPanY / 2);
+
+  ctx.drawImage(
+    img,
+    Math.max(0, Math.min(sx, img.naturalWidth - sw)),
+    Math.max(0, Math.min(sy, img.naturalHeight - sh)),
+    sw,
+    sh,
+    x,
+    y,
+    w,
+    h,
+  );
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}

--- a/src/app/tools/img-grid/layout.tsx
+++ b/src/app/tools/img-grid/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Image Grid",
+  description:
+    "Combine multiple images into a single composition. Drop, drag, pan, zoom, export — entirely client-side.",
+  openGraph: {
+    title: "Image Grid | MTosity Tools",
+    description:
+      "Combine multiple images into a single composition. Drop, drag, pan, zoom, export — entirely client-side.",
+    url: "https://mtosity.com/tools/img-grid",
+  },
+};
+
+export default function ImgGridLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/tools/img-grid/page.tsx
+++ b/src/app/tools/img-grid/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { SlideTabs } from "@/components/SlideTabs";
+import Sidebar from "./_components/Sidebar";
+import Canvas from "./_components/Canvas";
+import { useImageCombiner } from "./_components/useImageCombiner";
+
+export default function ImgGridPage() {
+  const c = useImageCombiner();
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        color: "var(--fg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <SlideTabs />
+
+      {/* Header strip */}
+      <motion.header
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+        style={{
+          paddingTop: "calc(56px + 1.5rem)",
+          padding: "calc(56px + 1.25rem) clamp(1.25rem, 4vw, 2rem) 1.25rem",
+          borderBottom: "1px solid var(--border)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.85rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <Link
+            href="/tools"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+              textDecoration: "none",
+              borderBottom: "1px solid var(--border-light)",
+              paddingBottom: "1px",
+            }}
+          >
+            ← All tools
+          </Link>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.18em",
+              color: "var(--muted)",
+              textTransform: "uppercase",
+            }}
+          >
+            07.03 — TOOL
+          </span>
+          <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.18em",
+              color: "var(--muted)",
+              textTransform: "uppercase",
+            }}
+            className="ig-stack-label"
+          >
+            CANVAS · 100% CLIENT-SIDE
+          </span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            gap: "1.5rem",
+            flexWrap: "wrap",
+          }}
+        >
+          <h1
+            style={{
+              fontFamily: "var(--font-crimson-text), Georgia, serif",
+              fontSize: "clamp(1.85rem, 4.5vw, 2.75rem)",
+              fontWeight: 700,
+              letterSpacing: "-0.025em",
+              lineHeight: 1.05,
+              margin: 0,
+            }}
+          >
+            Image{" "}
+            <span style={{ fontStyle: "italic", color: "var(--muted)" }}>
+              grid.
+            </span>
+          </h1>
+          <p
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.72rem",
+              letterSpacing: "0.1em",
+              color: "var(--muted)",
+              maxWidth: "60ch",
+              margin: 0,
+              lineHeight: 1.6,
+            }}
+            className="ig-tagline"
+          >
+            Drop images → choose a layout → pan / zoom each tile (drag to pan,
+            scroll to zoom) → export PNG. Nothing leaves your browser.
+          </p>
+        </div>
+      </motion.header>
+
+      {/* Workspace */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.1 }}
+        style={{
+          display: "flex",
+          flex: 1,
+          minHeight: "calc(100vh - 56px - 110px)",
+          overflow: "hidden",
+        }}
+        className="ig-workspace"
+      >
+        <Sidebar
+          imageCount={c.imageCount}
+          setImageCount={c.setImageCount}
+          aspectRatio={c.aspectRatio}
+          setAspectRatio={c.setAspectRatio}
+          layoutIndex={c.layoutIndex}
+          setLayoutIndex={c.setLayoutIndex}
+          layouts={c.layouts}
+          gap={c.gap}
+          setGap={c.setGap}
+          exportSize={c.exportSize}
+          setExportSize={c.setExportSize}
+          bgColor={c.bgColor}
+          setBgColor={c.setBgColor}
+          borderRadius={c.borderRadius}
+          setBorderRadius={c.setBorderRadius}
+          exportImage={c.exportImage}
+          images={c.images}
+        />
+        <Canvas
+          currentLayout={c.currentLayout}
+          aspectRatio={c.aspectRatio}
+          images={c.images}
+          onUpload={c.handleImageUpload}
+          onRemove={c.handleRemoveImage}
+          onTransform={c.handleImageTransform}
+          gap={c.gap}
+          bgColor={c.bgColor}
+          borderRadius={c.borderRadius}
+        />
+      </motion.div>
+
+      <style jsx global>{`
+        @media (max-width: 768px) {
+          .ig-workspace {
+            flex-direction: column !important;
+          }
+          .ig-sidebar {
+            width: 100% !important;
+            max-height: 50vh;
+            border-right: none !important;
+            border-bottom: 1px solid var(--border);
+          }
+          .ig-stack-label {
+            display: none;
+          }
+          .ig-tagline {
+            display: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/tools/instagram/layout.tsx
+++ b/src/app/tools/instagram/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Instagram Reel Extractor",
+  description:
+    "Paste a public Instagram reel URL to grab the video, the audio, or a full transcript — Whisper runs locally in your browser.",
+  openGraph: {
+    title: "Instagram Reel Extractor | MTosity Tools",
+    description:
+      "Paste a public Instagram reel URL to grab the video, the audio, or a full transcript — Whisper runs locally in your browser.",
+    url: "https://mtosity.com/tools/instagram",
+  },
+};
+
+export default function InstagramLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/tools/instagram/page.tsx
+++ b/src/app/tools/instagram/page.tsx
@@ -1,0 +1,1054 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { SlideTabs } from "@/components/SlideTabs";
+
+type Info = {
+  title: string;
+  thumbnail: string | null;
+  duration: number | null;
+  uploader: string | null;
+  width: number | null;
+  height: number | null;
+};
+
+type Chunk = { text: string; timestamp: [number, number | null] };
+type TranscribeResult = { text: string; chunks?: Chunk[] };
+
+const STAGES = [
+  "Downloading audio",
+  "Decoding audio",
+  "Loading Whisper model",
+  "Transcribing",
+] as const;
+type Stage = "" | (typeof STAGES)[number];
+
+export default function InstagramToolPage() {
+  const [url, setUrl] = useState("");
+  const [info, setInfo] = useState<Info | null>(null);
+  const [fetching, setFetching] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [stage, setStage] = useState<Stage>("");
+  const [modelProgress, setModelProgress] = useState(0);
+  const [transcript, setTranscript] = useState<TranscribeResult | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+  const workerRef = useRef<Worker | null>(null);
+  const workerReadyRef = useRef<Promise<void> | null>(null);
+  const workerReadyResolveRef = useRef<(() => void) | null>(null);
+  const workerReadyRejectRef = useRef<((err: Error) => void) | null>(null);
+  const transcribeResolveRef = useRef<
+    ((r: TranscribeResult) => void) | null
+  >(null);
+  const transcribeRejectRef = useRef<((err: Error) => void) | null>(null);
+
+  // Lazily spin up the worker on first transcribe.
+  function ensureWorker() {
+    if (workerRef.current) return workerReadyRef.current!;
+
+    const worker = new Worker(
+      new URL("../../../workers/whisper-worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    workerRef.current = worker;
+
+    workerReadyRef.current = new Promise<void>((resolve, reject) => {
+      workerReadyResolveRef.current = resolve;
+      workerReadyRejectRef.current = reject;
+    });
+
+    worker.addEventListener(
+      "message",
+      (e: MessageEvent<
+        | { type: "progress"; payload: { status: string; loaded?: number; total?: number; progress?: number } }
+        | { type: "ready" }
+        | { type: "result"; payload: TranscribeResult }
+        | { type: "error"; message: string }
+      >) => {
+        const m = e.data;
+        if (m.type === "progress") {
+          const p = m.payload;
+          if (p.status === "progress") {
+            const pct =
+              typeof p.progress === "number"
+                ? Math.round(p.progress)
+                : p.total
+                  ? Math.round(((p.loaded ?? 0) / p.total) * 100)
+                  : 0;
+            if (pct > 0) setModelProgress(pct);
+          }
+        } else if (m.type === "ready") {
+          workerReadyResolveRef.current?.();
+          workerReadyResolveRef.current = null;
+          workerReadyRejectRef.current = null;
+        } else if (m.type === "result") {
+          transcribeResolveRef.current?.(m.payload);
+          transcribeResolveRef.current = null;
+          transcribeRejectRef.current = null;
+        } else if (m.type === "error") {
+          const err = new Error(m.message);
+          if (transcribeRejectRef.current) {
+            transcribeRejectRef.current(err);
+            transcribeResolveRef.current = null;
+            transcribeRejectRef.current = null;
+          } else if (workerReadyRejectRef.current) {
+            workerReadyRejectRef.current(err);
+            workerReadyResolveRef.current = null;
+            workerReadyRejectRef.current = null;
+          }
+        }
+      },
+    );
+
+    worker.postMessage({
+      type: "init",
+      model: "onnx-community/whisper-base.en",
+      dtype: { encoder_model: "fp32", decoder_model_merged: "q4" },
+      device: "wasm",
+    });
+
+    return workerReadyRef.current;
+  }
+
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  async function handleFetch(e?: React.FormEvent) {
+    e?.preventDefault();
+    setError("");
+    setInfo(null);
+    setTranscript(null);
+    setFetching(true);
+    try {
+      const res = await fetch("/api/instagram/info", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to load reel");
+      setInfo(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setFetching(false);
+    }
+  }
+
+  function handleDownload() {
+    window.location.href = `/api/instagram/download?url=${encodeURIComponent(url)}`;
+  }
+
+  async function handleTranscribe() {
+    setTranscribing(true);
+    setError("");
+    setTranscript(null);
+    setModelProgress(0);
+    abortRef.current = new AbortController();
+    try {
+      setStage("Downloading audio");
+      const audioRes = await fetch(
+        `/api/instagram/audio?url=${encodeURIComponent(url)}`,
+        { signal: abortRef.current.signal },
+      );
+      if (!audioRes.ok) {
+        const body = await audioRes.json().catch(() => ({}));
+        throw new Error(body.error ?? "Failed to fetch audio");
+      }
+      const audioBuf = await audioRes.arrayBuffer();
+
+      setStage("Decoding audio");
+      const audio = await decodeTo16kMono(audioBuf);
+
+      setStage("Loading Whisper model");
+      await ensureWorker();
+
+      setStage("Transcribing");
+      const output = await new Promise<TranscribeResult>((resolve, reject) => {
+        transcribeResolveRef.current = resolve;
+        transcribeRejectRef.current = reject;
+        workerRef.current!.postMessage(
+          {
+            type: "transcribe",
+            audio,
+            options: {
+              chunk_length_s: 30,
+              stride_length_s: 5,
+              return_timestamps: true,
+            },
+          },
+          [audio.buffer],
+        );
+      });
+
+      setTranscript(output);
+      setStage("");
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setTranscribing(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!transcript) return;
+    await navigator.clipboard.writeText(transcript.text.trim());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  }
+
+  function downloadBlob(filename: string, contents: string, mime: string) {
+    const blob = new Blob([contents], { type: mime });
+    const href = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = href;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(href);
+  }
+
+  const stageIdx = STAGES.indexOf(stage as (typeof STAGES)[number]);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--fg)" }}>
+      <SlideTabs />
+
+      <main
+        style={{
+          maxWidth: "960px",
+          margin: "0 auto",
+          padding: "calc(56px + 3rem) clamp(1.5rem, 5vw, 4rem) 6rem",
+        }}
+      >
+        {/* Crumbs */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <Link
+            href="/tools"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+              textDecoration: "none",
+              borderBottom: "1px solid var(--border-light)",
+              paddingBottom: "1px",
+            }}
+          >
+            ← All tools
+          </Link>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "1rem",
+              marginTop: "1.5rem",
+              paddingBottom: "1rem",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                letterSpacing: "0.18em",
+                color: "var(--muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              07.02 — TOOL
+            </span>
+            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                letterSpacing: "0.18em",
+                color: "var(--muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              YT-DLP · WHISPER · WASM
+            </span>
+          </div>
+        </motion.div>
+
+        {/* Title */}
+        <motion.h1
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.05, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            fontFamily: "var(--font-crimson-text), Georgia, serif",
+            fontSize: "clamp(2.5rem, 6vw, 4.5rem)",
+            fontWeight: 700,
+            letterSpacing: "-0.025em",
+            lineHeight: 1.05,
+            margin: "2.5rem 0 1rem",
+          }}
+        >
+          Instagram reels,{" "}
+          <span style={{ fontStyle: "italic", color: "var(--muted)" }}>
+            extracted.
+          </span>
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.15, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            fontSize: "1.0625rem",
+            lineHeight: 1.7,
+            color: "var(--muted)",
+            maxWidth: "58ch",
+            margin: 0,
+          }}
+        >
+          Paste a public reel URL to grab the MP4 or run a full transcript.
+          Audio is fetched server-side via yt-dlp; the transcription itself runs
+          locally in your browser via WebAssembly Whisper. No accounts, no
+          storage.
+        </motion.p>
+
+        {/* URL form */}
+        <motion.form
+          onSubmit={handleFetch}
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.25, ease: [0.22, 1, 0.36, 1] }}
+          style={{ marginTop: "3rem" }}
+        >
+          <label
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+              display: "block",
+              marginBottom: "0.6rem",
+            }}
+          >
+            Reel URL
+          </label>
+          <div
+            style={{
+              display: "flex",
+              gap: "0.75rem",
+              flexWrap: "wrap",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              padding: "0.5rem",
+              boxShadow: "4px 4px 0 var(--border)",
+            }}
+          >
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://www.instagram.com/reel/..."
+              required
+              style={{
+                flex: 1,
+                minWidth: "260px",
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                padding: "0.85rem 1rem",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.9rem",
+                color: "var(--fg)",
+              }}
+            />
+            <motion.button
+              type="submit"
+              disabled={fetching || !url}
+              whileHover={!fetching && url ? { scale: 1.02 } : {}}
+              whileTap={!fetching && url ? { scale: 0.98 } : {}}
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                fontWeight: 700,
+                color: "var(--fg)",
+                background: fetching || !url ? "var(--border-light)" : "var(--accent)",
+                border: "1px solid var(--border)",
+                padding: "0.85rem 1.5rem",
+                cursor: fetching || !url ? "not-allowed" : "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.5rem",
+              }}
+            >
+              {fetching ? <Spinner /> : <span>→</span>}
+              Fetch
+            </motion.button>
+          </div>
+          <p
+            style={{
+              marginTop: "0.65rem",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.65rem",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+            }}
+          >
+            Supports /reel/, /reels/, /p/ and /tv/ links · public posts only
+          </p>
+        </motion.form>
+
+        {/* Error */}
+        <AnimatePresence>
+          {error && (
+            <motion.div
+              key="err"
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.25 }}
+              style={{
+                marginTop: "1.25rem",
+                border: "1px solid #a83232",
+                borderLeft: "3px solid #a83232",
+                background: "var(--bg-secondary)",
+                color: "#a83232",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.78rem",
+                lineHeight: 1.6,
+                padding: "0.85rem 1rem",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {error}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Info card */}
+        <AnimatePresence>
+          {info && (
+            <motion.section
+              key="info"
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+              style={{
+                marginTop: "2rem",
+                border: "1px solid var(--border)",
+                background: "var(--bg-secondary)",
+                padding: "clamp(1.25rem, 3vw, 1.75rem)",
+                boxShadow: "6px 6px 0 var(--border)",
+                display: "grid",
+                gridTemplateColumns: "minmax(0, 160px) 1fr",
+                gap: "clamp(1rem, 3vw, 1.75rem)",
+                alignItems: "start",
+              }}
+              className="ig-info-card"
+            >
+              {info.thumbnail ? (
+                <div
+                  style={{
+                    width: "100%",
+                    aspectRatio: "9/16",
+                    border: "1px solid var(--border-light)",
+                    background: "var(--bg)",
+                    overflow: "hidden",
+                    position: "relative",
+                  }}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={`/api/instagram/thumb?url=${encodeURIComponent(info.thumbnail)}`}
+                    alt=""
+                    referrerPolicy="no-referrer"
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                      display: "block",
+                    }}
+                  />
+                </div>
+              ) : (
+                <div
+                  style={{
+                    width: "100%",
+                    aspectRatio: "9/16",
+                    border: "1px solid var(--border-light)",
+                    background: "var(--bg)",
+                  }}
+                />
+              )}
+
+              <div style={{ minWidth: 0 }}>
+                {info.uploader && (
+                  <div
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.65rem",
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      color: "var(--muted)",
+                      marginBottom: "0.5rem",
+                    }}
+                  >
+                    @{info.uploader}
+                  </div>
+                )}
+                <h2
+                  style={{
+                    fontFamily: "var(--font-crimson-text), Georgia, serif",
+                    fontSize: "1.4rem",
+                    fontWeight: 600,
+                    lineHeight: 1.3,
+                    letterSpacing: "-0.01em",
+                    margin: 0,
+                    overflow: "hidden",
+                    display: "-webkit-box",
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                >
+                  {info.title}
+                </h2>
+                <div
+                  style={{
+                    marginTop: "0.55rem",
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: "0.5rem",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.65rem",
+                    letterSpacing: "0.12em",
+                    textTransform: "uppercase",
+                    color: "var(--muted)",
+                  }}
+                >
+                  {info.duration != null && (
+                    <span
+                      style={{
+                        border: "1px solid var(--border-light)",
+                        padding: "0.18rem 0.55rem",
+                      }}
+                    >
+                      {formatDuration(info.duration)}
+                    </span>
+                  )}
+                  {info.width && info.height && (
+                    <span
+                      style={{
+                        border: "1px solid var(--border-light)",
+                        padding: "0.18rem 0.55rem",
+                      }}
+                    >
+                      {info.width}×{info.height}
+                    </span>
+                  )}
+                </div>
+
+                <div
+                  style={{
+                    marginTop: "1.25rem",
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: "0.6rem",
+                  }}
+                >
+                  <PrimaryAction onClick={handleDownload}>
+                    <ArrowDownIcon />
+                    Download MP4
+                  </PrimaryAction>
+                  <AccentAction
+                    onClick={handleTranscribe}
+                    disabled={transcribing}
+                    busy={transcribing}
+                  >
+                    {transcribing ? <Spinner /> : <FileIcon />}
+                    Get transcript
+                  </AccentAction>
+                </div>
+
+                {transcribing && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    style={{ marginTop: "1.1rem" }}
+                  >
+                    <ol
+                      style={{
+                        listStyle: "none",
+                        margin: 0,
+                        padding: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: "0.4rem",
+                      }}
+                    >
+                      {STAGES.map((s, i) => {
+                        const state =
+                          i < stageIdx
+                            ? "done"
+                            : i === stageIdx
+                              ? "active"
+                              : "pending";
+                        return (
+                          <li
+                            key={s}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "0.6rem",
+                              fontFamily: "var(--font-mono)",
+                              fontSize: "0.7rem",
+                              letterSpacing: "0.1em",
+                              textTransform: "uppercase",
+                              color:
+                                state === "pending"
+                                  ? "var(--border-light)"
+                                  : state === "active"
+                                    ? "var(--fg)"
+                                    : "var(--muted)",
+                            }}
+                          >
+                            <StageDot state={state} />
+                            <span>
+                              {s}
+                              {s === "Loading Whisper model" &&
+                              modelProgress > 0
+                                ? ` — ${modelProgress}%`
+                                : ""}
+                            </span>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  </motion.div>
+                )}
+              </div>
+
+              <style jsx>{`
+                @media (max-width: 600px) {
+                  :global(.ig-info-card) {
+                    grid-template-columns: 1fr !important;
+                  }
+                  :global(.ig-info-card) > div:first-child {
+                    max-width: 220px;
+                    margin: 0 auto;
+                  }
+                }
+              `}</style>
+            </motion.section>
+          )}
+        </AnimatePresence>
+
+        {/* Transcript */}
+        <AnimatePresence>
+          {transcript && (
+            <motion.section
+              key="transcript"
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+              style={{ marginTop: "2.25rem" }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "1rem",
+                  marginBottom: "1rem",
+                  flexWrap: "wrap",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.7rem",
+                    letterSpacing: "0.2em",
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  TRANSCRIPT
+                </span>
+                <div
+                  style={{
+                    flex: 1,
+                    height: 1,
+                    background: "var(--border-light)",
+                    minWidth: "40px",
+                  }}
+                />
+                <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+                  <SmallBtn onClick={handleCopy}>
+                    {copied ? "Copied" : "Copy"}
+                  </SmallBtn>
+                  <SmallBtn
+                    onClick={() =>
+                      downloadBlob(
+                        "transcript.txt",
+                        transcript.text.trim(),
+                        "text/plain",
+                      )
+                    }
+                  >
+                    .txt
+                  </SmallBtn>
+                  {transcript.chunks && (
+                    <SmallBtn
+                      onClick={() =>
+                        downloadBlob(
+                          "transcript.srt",
+                          toSrt(transcript.chunks!),
+                          "application/x-subrip",
+                        )
+                      }
+                    >
+                      .srt
+                    </SmallBtn>
+                  )}
+                </div>
+              </div>
+
+              <div
+                style={{
+                  border: "1px solid var(--border-light)",
+                  background: "var(--bg-secondary)",
+                  padding: "1.5rem 1.75rem",
+                  fontSize: "1.0625rem",
+                  lineHeight: 1.75,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  fontFamily: "var(--font-crimson-text), Georgia, serif",
+                  color: "var(--fg)",
+                }}
+              >
+                {transcript.text.trim()}
+              </div>
+            </motion.section>
+          )}
+        </AnimatePresence>
+
+        {/* Footnote row */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.7, delay: 0.5 }}
+          style={{
+            marginTop: "3rem",
+            paddingTop: "1.5rem",
+            borderTop: "1px solid var(--border-light)",
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "1.5rem",
+          }}
+        >
+          <Footnote label="DOWNLOADER" value="yt-dlp · server-side" />
+          <Footnote label="TRANSCRIPTION" value="whisper-base.en · WASM" />
+          <Footnote label="STORAGE" value="None — nothing persisted" />
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+/* ── UI primitives ─────────────────────────────────────────────────── */
+
+function PrimaryAction({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <motion.button
+      onClick={onClick}
+      disabled={disabled}
+      whileHover={!disabled ? { scale: 1.02 } : {}}
+      whileTap={!disabled ? { scale: 0.97 } : {}}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.72rem",
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        fontWeight: 700,
+        color: "var(--fg)",
+        background: "var(--bg)",
+        border: "1px solid var(--border)",
+        padding: "0.7rem 1rem",
+        cursor: disabled ? "not-allowed" : "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+      }}
+    >
+      {children}
+    </motion.button>
+  );
+}
+
+function AccentAction({
+  children,
+  onClick,
+  disabled,
+  busy,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  busy?: boolean;
+}) {
+  return (
+    <motion.button
+      onClick={onClick}
+      disabled={disabled}
+      whileHover={!disabled ? { scale: 1.02 } : {}}
+      whileTap={!disabled ? { scale: 0.97 } : {}}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.72rem",
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        fontWeight: 700,
+        color: "var(--fg)",
+        background: busy ? "var(--border-light)" : "var(--accent)",
+        border: "1px solid var(--border)",
+        padding: "0.7rem 1rem",
+        cursor: disabled ? "not-allowed" : "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        opacity: disabled && !busy ? 0.55 : 1,
+      }}
+    >
+      {children}
+    </motion.button>
+  );
+}
+
+function SmallBtn({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.65rem",
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        color: "var(--fg)",
+        background: "transparent",
+        border: "1px solid var(--border-light)",
+        padding: "0.35rem 0.7rem",
+        cursor: "pointer",
+        transition: "border-color 0.15s, background 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--fg)";
+        (e.currentTarget as HTMLElement).style.background = "var(--bg-secondary)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--border-light)";
+        (e.currentTarget as HTMLElement).style.background = "transparent";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Footnote({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.65rem",
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--muted)",
+          marginBottom: "0.35rem",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.8rem",
+          color: "var(--fg)",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function StageDot({ state }: { state: "done" | "active" | "pending" }) {
+  if (state === "done") {
+    return (
+      <span
+        style={{
+          width: 12,
+          height: 12,
+          border: "1px solid var(--muted)",
+          background: "var(--muted)",
+          display: "inline-block",
+        }}
+      />
+    );
+  }
+  if (state === "active") {
+    return (
+      <motion.span
+        animate={{ opacity: [1, 0.3, 1] }}
+        transition={{ duration: 1.2, repeat: Infinity }}
+        style={{
+          width: 12,
+          height: 12,
+          border: "1px solid var(--fg)",
+          background: "var(--accent)",
+          display: "inline-block",
+        }}
+      />
+    );
+  }
+  return (
+    <span
+      style={{
+        width: 12,
+        height: 12,
+        border: "1px solid var(--border-light)",
+        background: "transparent",
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+function Spinner() {
+  return (
+    <motion.span
+      animate={{ rotate: 360 }}
+      transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
+      style={{
+        width: 12,
+        height: 12,
+        border: "2px solid var(--fg)",
+        borderTopColor: "transparent",
+        borderRadius: "50%",
+        display: "inline-block",
+      }}
+      aria-hidden
+    />
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M8 2v10m0 0l-4-4m4 4l4-4M2 14h12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+    </svg>
+  );
+}
+
+function FileIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M3 2h7l3 3v9H3V2z M10 2v3h3 M5 8h6 M5 11h6"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      />
+    </svg>
+  );
+}
+
+/* ── Helpers ───────────────────────────────────────────────────────── */
+
+async function decodeTo16kMono(buffer: ArrayBuffer): Promise<Float32Array> {
+  const Ctx =
+    (window.AudioContext as typeof AudioContext | undefined) ??
+    ((window as unknown as { webkitAudioContext: typeof AudioContext })
+      .webkitAudioContext as typeof AudioContext);
+  const ctx = new Ctx({ sampleRate: 16000 });
+  try {
+    const decoded = await ctx.decodeAudioData(buffer.slice(0));
+    // Always return a freshly-allocated Float32Array — its buffer is transferable
+    // to the worker, where AudioBuffer-internal channel views are not.
+    if (decoded.numberOfChannels === 1) {
+      return new Float32Array(decoded.getChannelData(0));
+    }
+    const left = decoded.getChannelData(0);
+    const right = decoded.getChannelData(1);
+    const merged = new Float32Array(left.length);
+    for (let i = 0; i < left.length; i++) merged[i] = (left[i] + right[i]) / 2;
+    return merged;
+  } finally {
+    ctx.close();
+  }
+}
+
+function formatDuration(seconds: number) {
+  const s = Math.round(seconds);
+  const m = Math.floor(s / 60);
+  const rest = s % 60;
+  return `${m}:${String(rest).padStart(2, "0")}`;
+}
+
+function toSrt(chunks: Chunk[]) {
+  return chunks
+    .map((c, i) => {
+      const [start, endRaw] = c.timestamp;
+      const end = endRaw ?? start + 2;
+      return `${i + 1}\n${srtTime(start)} --> ${srtTime(end)}\n${c.text.trim()}\n`;
+    })
+    .join("\n");
+}
+
+function srtTime(t: number) {
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = Math.floor(t % 60);
+  const ms = Math.floor((t - Math.floor(t)) * 1000);
+  return `${pad(h)}:${pad(m)}:${pad(s)},${pad(ms, 3)}`;
+}
+
+function pad(n: number, width = 2) {
+  return String(n).padStart(width, "0");
+}

--- a/src/app/tools/layout.tsx
+++ b/src/app/tools/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Tools",
+  description:
+    "Small browser-only tools I've built for myself. No accounts, no uploads, no telemetry.",
+  openGraph: {
+    title: "Tools | MTosity",
+    description:
+      "Small browser-only tools I've built for myself. No accounts, no uploads, no telemetry.",
+    url: "https://mtosity.com/tools",
+  },
+};
+
+export default function ToolsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { SlideTabs } from "@/components/SlideTabs";
+import { tools, type ToolIconName } from "@/data/tools";
+
+const STATUS_LABEL: Record<string, string> = {
+  live: "● LIVE",
+  beta: "◐ BETA",
+  wip: "○ WIP",
+};
+
+export default function ToolsPage() {
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--fg)" }}>
+      <SlideTabs />
+
+      <main
+        style={{
+          maxWidth: "1400px",
+          margin: "0 auto",
+          padding: "calc(56px + 4rem) clamp(1.5rem, 5vw, 4rem) 6rem",
+        }}
+      >
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "1rem",
+            paddingBottom: "1.25rem",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              letterSpacing: "0.2em",
+              color: "var(--muted)",
+            }}
+          >
+            07 —
+          </span>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.75rem",
+              fontWeight: 700,
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+            }}
+          >
+            TOOLS
+          </span>
+          <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.18em",
+              color: "var(--muted)",
+              textTransform: "uppercase",
+            }}
+          >
+            {tools.length.toString().padStart(2, "0")} ITEM{tools.length === 1 ? "" : "S"}
+          </span>
+        </motion.div>
+
+        {/* Tagline */}
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.1, ease: [0.22, 1, 0.36, 1] }}
+          style={{ padding: "3rem 0 4rem" }}
+        >
+          <h1
+            style={{
+              fontFamily: "var(--font-crimson-text), Georgia, serif",
+              fontSize: "clamp(2.5rem, 6vw, 4.75rem)",
+              fontWeight: 700,
+              lineHeight: 1.05,
+              letterSpacing: "-0.025em",
+              maxWidth: "18ch",
+              margin: 0,
+            }}
+          >
+            Small tools.{" "}
+            <span style={{ fontStyle: "italic", color: "var(--muted)" }}>
+              Built to be useful.
+            </span>
+          </h1>
+          <p
+            style={{
+              marginTop: "1.5rem",
+              fontSize: "1.0625rem",
+              lineHeight: 1.7,
+              color: "var(--muted)",
+              maxWidth: "52ch",
+            }}
+          >
+            A growing shelf of one-page utilities I&apos;ve built for myself —
+            most of them run entirely in your browser. No accounts, no uploads,
+            no telemetry.
+          </p>
+        </motion.div>
+
+        {/* Tools list */}
+        <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+          {tools.map((tool, i) => (
+            <ToolRow key={tool.slug} tool={tool} index={i} />
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}
+
+function ToolRow({
+  tool,
+  index,
+}: {
+  tool: (typeof tools)[number];
+  index: number;
+}) {
+  return (
+    <motion.li
+      initial={{ opacity: 0, clipPath: "inset(0 100% 0 0)" }}
+      animate={{ opacity: 1, clipPath: "inset(0 0% 0 0)" }}
+      transition={{
+        duration: 0.8,
+        delay: 0.25 + index * 0.08,
+        ease: [0.65, 0, 0.35, 1],
+      }}
+      style={{ borderBottom: "1px solid var(--border-light)" }}
+    >
+      <Link
+        href={`/tools/${tool.slug}`}
+        className="tool-row"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "auto auto 1fr auto",
+          alignItems: "start",
+          gap: "clamp(0.85rem, 2.5vw, 1.75rem)",
+          padding: "1.75rem 1rem",
+          color: "var(--fg)",
+          textDecoration: "none",
+          position: "relative",
+          transition: "background 0.3s ease, padding 0.3s ease",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.75rem",
+            letterSpacing: "0.18em",
+            color: "var(--muted)",
+            minWidth: "3ch",
+            paddingTop: "0.55rem",
+          }}
+        >
+          {String(index + 1).padStart(2, "0")}
+        </span>
+
+        <ToolThumbnail name={tool.icon} />
+
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: "0.75rem",
+              flexWrap: "wrap",
+              marginBottom: "0.5rem",
+            }}
+          >
+            <h2
+              style={{
+                fontFamily: "var(--font-crimson-text), Georgia, serif",
+                fontSize: "clamp(1.5rem, 3.5vw, 2.25rem)",
+                fontWeight: 700,
+                letterSpacing: "-0.02em",
+                margin: 0,
+                lineHeight: 1.1,
+              }}
+            >
+              {tool.title}
+            </h2>
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.65rem",
+                letterSpacing: "0.15em",
+                color: "var(--muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              {STATUS_LABEL[tool.status]} · {tool.year}
+            </span>
+          </div>
+          <p
+            style={{
+              fontSize: "1rem",
+              color: "var(--muted)",
+              lineHeight: 1.6,
+              margin: "0 0 0.85rem",
+              maxWidth: "62ch",
+            }}
+          >
+            {tool.description}
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem" }}>
+            {tool.tags.map((tag) => (
+              <span
+                key={tag}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.65rem",
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  color: "var(--muted)",
+                  border: "1px solid var(--border-light)",
+                  padding: "0.18rem 0.55rem",
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <span
+          aria-hidden
+          className="tool-arrow"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.95rem",
+            color: "var(--fg)",
+            transform: "translateX(0)",
+            transition: "transform 0.3s ease",
+            display: "inline-block",
+          }}
+        >
+          →
+        </span>
+      </Link>
+
+      <style jsx>{`
+        .tool-row:hover {
+          background: var(--accent);
+          padding-left: 1.5rem !important;
+        }
+        .tool-row:hover :global(.tool-arrow) {
+          transform: translateX(8px);
+        }
+        .tool-row:hover :global(.tool-thumb) {
+          background: var(--bg);
+          border-color: var(--fg);
+        }
+        .tool-row:hover :global(.tool-thumb svg) {
+          transform: rotate(-4deg) scale(1.05);
+        }
+      `}</style>
+    </motion.li>
+  );
+}
+
+function ToolThumbnail({ name }: { name: ToolIconName }) {
+  return (
+    <div
+      className="tool-thumb"
+      style={{
+        width: "clamp(56px, 8vw, 72px)",
+        height: "clamp(56px, 8vw, 72px)",
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border-light)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        transition: "background 0.25s ease, border-color 0.25s ease",
+        position: "relative",
+        overflow: "hidden",
+      }}
+      aria-hidden
+    >
+      <div
+        style={{
+          width: "60%",
+          height: "60%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--fg)",
+          transition: "transform 0.4s cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+      >
+        <ToolIcon name={name} />
+      </div>
+    </div>
+  );
+}
+
+function ToolIcon({ name }: { name: ToolIconName }) {
+  const stroke = "currentColor";
+  const sw = 1.5;
+
+  if (name === "mic") {
+    return (
+      <svg
+        viewBox="0 0 32 32"
+        fill="none"
+        stroke={stroke}
+        strokeWidth={sw}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ width: "100%", height: "100%" }}
+      >
+        <rect x="12" y="4" width="8" height="16" rx="4" />
+        <path d="M6 14a10 10 0 0 0 20 0" />
+        <line x1="16" y1="24" x2="16" y2="28" />
+        <line x1="11" y1="28" x2="21" y2="28" />
+        {/* sound arcs */}
+        <path d="M3 12c0 1.5 0.4 2.9 1 4" opacity="0.5" />
+        <path d="M29 12c0 1.5 -0.4 2.9 -1 4" opacity="0.5" />
+      </svg>
+    );
+  }
+
+  if (name === "grid") {
+    return (
+      <svg
+        viewBox="0 0 32 32"
+        fill="none"
+        stroke={stroke}
+        strokeWidth={sw}
+        strokeLinejoin="miter"
+        style={{ width: "100%", height: "100%" }}
+      >
+        <rect x="4" y="4" width="11" height="11" />
+        <rect x="17" y="4" width="11" height="11" />
+        <rect x="4" y="17" width="11" height="11" />
+        <rect x="17" y="17" width="11" height="11" />
+        {/* "image" hint inside top-left tile */}
+        <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+        <path d="M5 13l3-3 4 4" />
+      </svg>
+    );
+  }
+
+  // reel — phone-shape with play triangle
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      fill="none"
+      stroke={stroke}
+      strokeWidth={sw}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ width: "100%", height: "100%" }}
+    >
+      <rect x="9" y="2" width="14" height="28" rx="2.5" />
+      <line x1="13" y1="5" x2="19" y2="5" opacity="0.5" />
+      <circle cx="16" cy="26.5" r="0.9" fill="currentColor" />
+      <path d="M14 13l6 3 -6 3 z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/src/app/tools/speech-to-text/layout.tsx
+++ b/src/app/tools/speech-to-text/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Speech to Text",
+  description:
+    "On-device speech transcription with Whisper. Runs entirely in your browser — no audio leaves your device.",
+  openGraph: {
+    title: "Speech to Text | MTosity Tools",
+    description:
+      "On-device speech transcription with Whisper. Runs entirely in your browser — no audio leaves your device.",
+    url: "https://mtosity.com/tools/speech-to-text",
+  },
+};
+
+export default function STTLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/tools/speech-to-text/page.tsx
+++ b/src/app/tools/speech-to-text/page.tsx
@@ -1,0 +1,768 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { SlideTabs } from "@/components/SlideTabs";
+
+type Phase = "loading" | "ready" | "recording" | "transcribing" | "error";
+
+export default function SpeechToTextPage() {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [statusMsg, setStatusMsg] = useState("Loading model — first run pulls ~150MB.");
+  const [progress, setProgress] = useState(0);
+  const [transcript, setTranscript] = useState("");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [levels, setLevels] = useState<number[]>(() => Array(28).fill(0.05));
+  const [elapsed, setElapsed] = useState(0);
+
+  const workerRef = useRef<Worker | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const transcribeResolveRef = useRef<
+    ((text: string) => void) | null
+  >(null);
+  const transcribeRejectRef = useRef<((err: Error) => void) | null>(null);
+
+  // Spin up the worker and load the model once.
+  useEffect(() => {
+    const worker = new Worker(
+      new URL("../../../workers/whisper-worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    workerRef.current = worker;
+
+    worker.addEventListener(
+      "message",
+      (e: MessageEvent<
+        | { type: "progress"; payload: { status: string; loaded?: number; total?: number; progress?: number } }
+        | { type: "ready" }
+        | { type: "result"; payload: { text: string } }
+        | { type: "error"; message: string }
+      >) => {
+        const m = e.data;
+        if (m.type === "progress") {
+          const p = m.payload;
+          if (p.status === "progress") {
+            const pct =
+              typeof p.progress === "number"
+                ? Math.round(p.progress)
+                : p.total
+                  ? Math.round(((p.loaded ?? 0) / p.total) * 100)
+                  : 0;
+            if (pct > 0) {
+              setProgress(pct);
+              setStatusMsg(`Loading model — ${pct}%`);
+            }
+          }
+        } else if (m.type === "ready") {
+          setPhase("ready");
+          setProgress(100);
+          setStatusMsg("Ready. Tap the mic to begin.");
+        } else if (m.type === "result") {
+          const text = (m.payload.text ?? "").trim();
+          transcribeResolveRef.current?.(text);
+          transcribeResolveRef.current = null;
+          transcribeRejectRef.current = null;
+        } else if (m.type === "error") {
+          if (transcribeRejectRef.current) {
+            transcribeRejectRef.current(new Error(m.message));
+            transcribeResolveRef.current = null;
+            transcribeRejectRef.current = null;
+          } else {
+            setErrorMsg(m.message);
+            setPhase("error");
+            setStatusMsg(`Failed to load model — ${m.message}`);
+          }
+        }
+      },
+    );
+
+    worker.postMessage({
+      type: "init",
+      model: "onnx-community/whisper-base.en",
+      dtype: { encoder_model: "fp32", decoder_model_merged: "q4" },
+      device: "wasm",
+    });
+
+    return () => {
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  const transcribeViaWorker = useCallback(
+    (audio: Float32Array): Promise<string> =>
+      new Promise<string>((resolve, reject) => {
+        const worker = workerRef.current;
+        if (!worker) {
+          reject(new Error("Worker not ready"));
+          return;
+        }
+        transcribeResolveRef.current = resolve;
+        transcribeRejectRef.current = reject;
+        worker.postMessage({ type: "transcribe", audio }, [audio.buffer]);
+      }),
+    [],
+  );
+
+  // Tick recording timer.
+  useEffect(() => {
+    if (phase !== "recording") return;
+    const id = window.setInterval(() => {
+      setElapsed(Math.floor((performance.now() - startedAtRef.current) / 1000));
+    }, 250);
+    return () => window.clearInterval(id);
+  }, [phase]);
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      audioCtxRef.current?.close().catch(() => {});
+    };
+  }, []);
+
+  const sampleLevels = useCallback(() => {
+    const analyser = analyserRef.current;
+    if (!analyser) return;
+    const buf = new Uint8Array(analyser.frequencyBinCount);
+
+    const tick = () => {
+      analyser.getByteFrequencyData(buf);
+      const bins = 28;
+      const step = Math.floor(buf.length / bins);
+      const next: number[] = [];
+      for (let i = 0; i < bins; i++) {
+        let sum = 0;
+        for (let j = 0; j < step; j++) sum += buf[i * step + j];
+        next.push(Math.min(1, sum / step / 200));
+      }
+      setLevels(next);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    tick();
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      audioChunksRef.current = [];
+
+      const mr = new MediaRecorder(stream, { mimeType: "audio/webm;codecs=opus" });
+      mediaRecorderRef.current = mr;
+
+      const ctx = new AudioContext();
+      audioCtxRef.current = ctx;
+      const source = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+
+      mr.ondataavailable = (e) => {
+        if (e.data.size > 0) audioChunksRef.current.push(e.data);
+      };
+
+      mr.onstop = async () => {
+        stream.getTracks().forEach((t) => t.stop());
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        await ctx.close().catch(() => {});
+        analyserRef.current = null;
+        audioCtxRef.current = null;
+        setLevels(Array(28).fill(0.05));
+
+        setPhase("transcribing");
+        setStatusMsg("Transcribing…");
+
+        try {
+          const blob = new Blob(audioChunksRef.current, { type: "audio/webm" });
+          const arrayBuf = await blob.arrayBuffer();
+          const decodeCtx = new AudioContext({ sampleRate: 16000 });
+          const decoded = await decodeCtx.decodeAudioData(arrayBuf);
+          // Copy the channel data so we own the buffer (we transfer it to the
+          // worker, which would detach the AudioBuffer's internal storage).
+          const float32 = new Float32Array(decoded.getChannelData(0));
+          await decodeCtx.close();
+
+          const text = await transcribeViaWorker(float32);
+          setTranscript((prev) => (prev ? prev + "\n" + text : text));
+          setPhase("ready");
+          setStatusMsg("Done. Tap the mic for another pass.");
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setErrorMsg(msg);
+          setStatusMsg(`Transcription error — ${msg}`);
+          setPhase("ready");
+        }
+      };
+
+      mr.start();
+      startedAtRef.current = performance.now();
+      setElapsed(0);
+      setPhase("recording");
+      setStatusMsg("Listening…");
+      sampleLevels();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setErrorMsg(msg);
+      setStatusMsg(`Mic permission denied — ${msg}`);
+      setPhase("ready");
+    }
+  }, [sampleLevels, transcribeViaWorker]);
+
+  const stopRecording = useCallback(() => {
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state !== "inactive") mr.stop();
+  }, []);
+
+  const handleMicClick = () => {
+    if (phase === "recording") stopRecording();
+    else if (phase === "ready") startRecording();
+  };
+
+  const handleCopy = () => {
+    if (!transcript.trim()) return;
+    navigator.clipboard.writeText(transcript.trim()).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    });
+  };
+
+  const handleClear = () => {
+    if (phase === "recording") stopRecording();
+    setTranscript("");
+    setStatusMsg("Ready. Tap the mic to begin.");
+  };
+
+  const isBusy = phase === "loading" || phase === "transcribing";
+  const isRecording = phase === "recording";
+
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--fg)" }}>
+      <SlideTabs />
+
+      <main
+        style={{
+          maxWidth: "960px",
+          margin: "0 auto",
+          padding: "calc(56px + 3rem) clamp(1.5rem, 5vw, 4rem) 6rem",
+        }}
+      >
+        {/* Crumbs + section header */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <Link
+            href="/tools"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+              textDecoration: "none",
+              borderBottom: "1px solid var(--border-light)",
+              paddingBottom: "1px",
+            }}
+          >
+            ← All tools
+          </Link>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "1rem",
+              marginTop: "1.5rem",
+              paddingBottom: "1rem",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                letterSpacing: "0.18em",
+                color: "var(--muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              07.01 — TOOL
+            </span>
+            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                letterSpacing: "0.18em",
+                color: "var(--muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              ON-DEVICE · WHISPER-BASE.EN
+            </span>
+          </div>
+        </motion.div>
+
+        {/* Title */}
+        <motion.h1
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.05, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            fontFamily: "var(--font-crimson-text), Georgia, serif",
+            fontSize: "clamp(2.5rem, 6vw, 4.5rem)",
+            fontWeight: 700,
+            letterSpacing: "-0.025em",
+            lineHeight: 1.05,
+            margin: "2.5rem 0 1rem",
+          }}
+        >
+          Speech <span style={{ fontStyle: "italic", color: "var(--muted)" }}>to</span> text.
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.15, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            fontSize: "1.0625rem",
+            lineHeight: 1.7,
+            color: "var(--muted)",
+            maxWidth: "58ch",
+            margin: 0,
+          }}
+        >
+          Records audio in your browser and runs an ONNX build of Whisper
+          (whisper-base.en) through WebAssembly via transformers.js. No API
+          calls, no uploads. The first visit downloads the model weights
+          (~150MB) and caches them locally.
+        </motion.p>
+
+        {/* Recorder card */}
+        <motion.section
+          initial={{ opacity: 0, y: 32 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.25, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            marginTop: "3rem",
+            border: "1px solid var(--border)",
+            background: "var(--bg-secondary)",
+            padding: "clamp(1.5rem, 4vw, 2.5rem)",
+            position: "relative",
+            boxShadow: "6px 6px 0 var(--border)",
+          }}
+        >
+          {/* Top meta */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--muted)",
+              marginBottom: "1.75rem",
+            }}
+          >
+            <span style={{ display: "flex", alignItems: "center", gap: "0.55rem" }}>
+              <StatusDot phase={phase} />
+              {phase}
+            </span>
+            <span>{formatTime(elapsed)}</span>
+          </div>
+
+          {/* Mic */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "1.5rem",
+            }}
+          >
+            <div style={{ position: "relative", width: 150, height: 150 }}>
+              {[0, 0.45, 0.9].map((delay) => (
+                <motion.span
+                  key={delay}
+                  initial={false}
+                  animate={
+                    isRecording
+                      ? { opacity: [0.35, 0], scale: [1, 2.3] }
+                      : { opacity: 0, scale: 1 }
+                  }
+                  transition={
+                    isRecording
+                      ? {
+                          duration: 1.6,
+                          delay,
+                          repeat: Infinity,
+                          ease: "easeOut",
+                        }
+                      : { duration: 0.15 }
+                  }
+                  style={{
+                    position: "absolute",
+                    inset: 0,
+                    borderRadius: "50%",
+                    border: "1px solid var(--fg)",
+                    background: "var(--accent)",
+                    pointerEvents: "none",
+                  }}
+                />
+              ))}
+              <motion.button
+                onClick={handleMicClick}
+                disabled={isBusy}
+                aria-label={isRecording ? "Stop recording" : "Start recording"}
+                whileHover={!isBusy ? { scale: 1.04 } : {}}
+                whileTap={!isBusy ? { scale: 0.96 } : {}}
+                animate={isRecording ? { scale: [1, 1.04, 1] } : { scale: 1 }}
+                transition={
+                  isRecording
+                    ? { duration: 1.4, repeat: Infinity, ease: "easeInOut" }
+                    : { duration: 0.2 }
+                }
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  width: "100%",
+                  height: "100%",
+                  borderRadius: "50%",
+                  border: "1px solid var(--border)",
+                  background: isRecording ? "var(--fg)" : "var(--accent)",
+                  cursor: isBusy ? "not-allowed" : "pointer",
+                  opacity: isBusy ? 0.55 : 1,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  boxShadow: isRecording
+                    ? "0 0 0 4px var(--bg-secondary), 6px 6px 0 var(--border)"
+                    : "6px 6px 0 var(--border)",
+                  transition: "background 0.2s, box-shadow 0.2s",
+                }}
+              >
+                {isRecording ? (
+                  <span
+                    style={{
+                      width: 26,
+                      height: 26,
+                      background: "var(--accent)",
+                      borderRadius: 2,
+                    }}
+                  />
+                ) : (
+                  <svg
+                    width="38"
+                    height="38"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="var(--fg)"
+                    strokeWidth="1.6"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect x="9" y="2" width="6" height="12" rx="3" />
+                    <path d="M5 10a7 7 0 0 0 14 0" />
+                    <line x1="12" y1="19" x2="12" y2="22" />
+                    <line x1="8" y1="22" x2="16" y2="22" />
+                  </svg>
+                )}
+              </motion.button>
+            </div>
+
+            {/* Waveform */}
+            <Waveform levels={levels} active={isRecording} />
+
+            {/* Status */}
+            <p
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: phase === "error" ? "#a83232" : "var(--muted)",
+                textAlign: "center",
+                margin: 0,
+                minHeight: "1em",
+              }}
+            >
+              {statusMsg}
+            </p>
+
+            {/* Loading bar */}
+            {phase === "loading" && (
+              <div
+                style={{
+                  width: "min(420px, 90%)",
+                  height: 3,
+                  background: "var(--border-light)",
+                  position: "relative",
+                  overflow: "hidden",
+                }}
+              >
+                <motion.div
+                  animate={{ width: `${progress}%` }}
+                  transition={{ duration: 0.3, ease: "easeOut" }}
+                  style={{ height: "100%", background: "var(--fg)" }}
+                />
+              </div>
+            )}
+          </div>
+        </motion.section>
+
+        {/* Transcript */}
+        <motion.section
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.4, ease: [0.22, 1, 0.36, 1] }}
+          style={{ marginTop: "3rem" }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "1rem",
+              marginBottom: "1rem",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.7rem",
+                letterSpacing: "0.2em",
+                fontWeight: 700,
+                textTransform: "uppercase",
+              }}
+            >
+              TRANSCRIPT
+            </span>
+            <div style={{ flex: 1, height: 1, background: "var(--border-light)" }} />
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <ActionBtn onClick={handleCopy} disabled={!transcript.trim()}>
+                {copied ? "Copied" : "Copy"}
+              </ActionBtn>
+              <ActionBtn
+                onClick={handleClear}
+                disabled={!transcript.trim() && phase !== "recording"}
+              >
+                Clear
+              </ActionBtn>
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid var(--border-light)",
+              background: "var(--bg)",
+              minHeight: "180px",
+              padding: "1.5rem 1.75rem",
+              fontSize: "1.0625rem",
+              lineHeight: 1.75,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontFamily: "var(--font-crimson-text), Georgia, serif",
+            }}
+          >
+            <AnimatePresence mode="wait">
+              {transcript ? (
+                <motion.div
+                  key="content"
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {transcript}
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="empty"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  style={{
+                    color: "var(--muted)",
+                    fontStyle: "italic",
+                    fontFamily: "var(--font-crimson-text), Georgia, serif",
+                  }}
+                >
+                  Your words will land here.
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.section>
+
+        {/* Footnote */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.7, delay: 0.6 }}
+          style={{
+            marginTop: "3rem",
+            paddingTop: "1.5rem",
+            borderTop: "1px solid var(--border-light)",
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: "1.5rem",
+          }}
+        >
+          <Footnote label="MODEL" value="whisper-base.en · q8" />
+          <Footnote label="RUNTIME" value="WebAssembly · transformers.js" />
+          <Footnote label="PRIVACY" value="No audio leaves your device" />
+        </motion.div>
+      </main>
+    </div>
+  );
+}
+
+function StatusDot({ phase }: { phase: Phase }) {
+  const color =
+    phase === "recording"
+      ? "#dc2626"
+      : phase === "ready"
+        ? "var(--fg)"
+        : phase === "error"
+          ? "#a83232"
+          : "var(--muted)";
+  return (
+    <motion.span
+      animate={
+        phase === "recording" || phase === "loading" || phase === "transcribing"
+          ? { opacity: [1, 0.3, 1] }
+          : { opacity: 1 }
+      }
+      transition={{ duration: 1.2, repeat: Infinity }}
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: "50%",
+        background: color,
+        display: "inline-block",
+      }}
+    />
+  );
+}
+
+function Waveform({ levels, active }: { levels: number[]; active: boolean }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 3,
+        height: 56,
+        width: "min(420px, 90%)",
+        justifyContent: "center",
+      }}
+      aria-hidden
+    >
+      {levels.map((lvl, i) => {
+        const h = active ? Math.max(4, lvl * 56) : 4 + Math.sin(i * 0.6) * 1.5;
+        return (
+          <motion.span
+            key={i}
+            animate={{ height: h }}
+            transition={{ duration: 0.08, ease: "linear" }}
+            style={{
+              width: 3,
+              borderRadius: 1,
+              background: active ? "var(--fg)" : "var(--border-light)",
+              display: "block",
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ActionBtn({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.7rem",
+        letterSpacing: "0.12em",
+        textTransform: "uppercase",
+        color: "var(--fg)",
+        background: "transparent",
+        border: "1px solid var(--border-light)",
+        padding: "0.4rem 0.85rem",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.4 : 1,
+        transition: "border-color 0.15s, background 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        if (disabled) return;
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--fg)";
+        (e.currentTarget as HTMLElement).style.background = "var(--bg-secondary)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--border-light)";
+        (e.currentTarget as HTMLElement).style.background = "transparent";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Footnote({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.65rem",
+          letterSpacing: "0.18em",
+          textTransform: "uppercase",
+          color: "var(--muted)",
+          marginBottom: "0.35rem",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.8rem",
+          color: "var(--fg)",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = (seconds % 60).toString().padStart(2, "0");
+  return `${m}:${s}`;
+}

--- a/src/components/SlideTabs.tsx
+++ b/src/components/SlideTabs.tsx
@@ -14,7 +14,7 @@ const NAV_LINKS = [
   { label: "About", href: "/" },
   { label: "Photos", href: "/photography" },
   { label: "Writing", href: "/blog" },
-  { label: "Contact", href: "/#contact" },
+  { label: "Tools", href: "/tools" },
 ];
 
 export const SlideTabs = () => {

--- a/src/components/template/home/experience/Experience.tsx
+++ b/src/components/template/home/experience/Experience.tsx
@@ -15,10 +15,19 @@ export const Experience = () => {
 
 const experience = [
   {
+    title: "SAS Institute",
+    link: "https://www.sas.com/",
+    position: "Software Engineer II",
+    time: "Apr 2026 – Present",
+    location: "",
+    description: "🌐 Localization l10n - i18n",
+    tech: [],
+  },
+  {
     title: "Coalition Inc",
     link: "https://www.youtube.com/watch?v=c27e3yi2g9E&ab_channel=Coalition%2CInc",
     position: "Software Engineer II",
-    time: "Jun 2022 – Present",
+    time: "Jun 2022 – April 2026",
     location: "",
     description:
       "• Reduced insurance quote generation latency by 58% by architecting a new internationalized (i18n) intake form using React, React Hook Form, and TanStack Query for real-time data synchronization.\n\n" +

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -1,0 +1,48 @@
+export type ToolIconName = "mic" | "grid" | "reel";
+
+export type Tool = {
+  slug: string;
+  title: string;
+  tagline: string;
+  description: string;
+  tags: string[];
+  status: "live" | "beta" | "wip";
+  year: string;
+  icon: ToolIconName;
+};
+
+export const tools: Tool[] = [
+  {
+    slug: "speech-to-text",
+    title: "Speech to Text",
+    tagline: "On-device transcription with Whisper.",
+    description:
+      "Press the mic, speak, get a transcript — no servers, no uploads. Whisper runs entirely in your browser via @huggingface/transformers + WebAssembly.",
+    tags: ["Whisper", "WASM", "Transformers.js", "Privacy"],
+    status: "live",
+    year: "2026",
+    icon: "mic",
+  },
+  {
+    slug: "img-grid",
+    title: "Image Grid",
+    tagline: "Combine multiple images into one composition.",
+    description:
+      "Drop images, pick a layout, pan / zoom each tile, export a PNG. Pure Canvas, zero uploads — everything runs in the browser.",
+    tags: ["Canvas", "Drag & drop", "Pan/zoom", "PNG export"],
+    status: "live",
+    year: "2026",
+    icon: "grid",
+  },
+  {
+    slug: "instagram",
+    title: "Instagram Reel Extractor",
+    tagline: "MP4, audio, or transcript from any public reel.",
+    description:
+      "Paste a public Instagram reel URL to download the video or generate a full transcript. Audio is fetched server-side via yt-dlp; transcription happens locally in-browser via WASM Whisper.",
+    tags: ["yt-dlp", "Whisper", "WASM", "Next.js API"],
+    status: "live",
+    year: "2026",
+    icon: "reel",
+  },
+];

--- a/src/lib/instagram-url.ts
+++ b/src/lib/instagram-url.ts
@@ -1,0 +1,10 @@
+const URL_RE =
+  /^https?:\/\/(?:www\.)?instagram\.com\/(reel|reels|p|tv)\/([A-Za-z0-9_-]+)/;
+
+export type InstagramRef = { shortcode: string; kind: string };
+
+export function parseInstagramUrl(input: string): InstagramRef | null {
+  const m = input.trim().match(URL_RE);
+  if (!m) return null;
+  return { kind: m[1], shortcode: m[2] };
+}

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,6 @@
+// JSON.stringify does not escape "</script>", which would let a string field
+// break out of the surrounding <script> tag. Escape "<" so the payload stays
+// inside the JSON-LD block no matter what.
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,45 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import type { NextRequest } from "next/server";
+
+type Result = { success: boolean; limit: number; remaining: number; reset: number };
+
+let cached: Ratelimit | null | undefined;
+
+function getLimiter(): Ratelimit | null {
+  if (cached !== undefined) return cached;
+  const hasKv =
+    (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) ||
+    (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
+  if (!hasKv) {
+    cached = null;
+    return cached;
+  }
+  const redis = new Redis({
+    url: (process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL)!,
+    token: (process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN)!,
+  });
+  cached = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(10, "1 h"),
+    prefix: "mtosity-tools-instagram",
+    analytics: true,
+  });
+  return cached;
+}
+
+function getIp(req: NextRequest): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "anonymous";
+}
+
+export async function checkRateLimit(req: NextRequest): Promise<Result> {
+  const limiter = getLimiter();
+  if (!limiter) {
+    return { success: true, limit: Infinity, remaining: Infinity, reset: 0 };
+  }
+  const ip = getIp(req);
+  const { success, limit, remaining, reset } = await limiter.limit(ip);
+  return { success, limit, remaining, reset };
+}

--- a/src/lib/yt-dlp.ts
+++ b/src/lib/yt-dlp.ts
@@ -1,56 +1,64 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import type { Readable } from "node:stream";
-import path from "node:path";
-import os from "node:os";
 import { existsSync, chmodSync, writeFileSync } from "node:fs";
 
-function resolveBinary(): string {
-  if (process.env.YT_DLP_PATH) return process.env.YT_DLP_PATH;
-  // Bracket-notation defeats Turbopack's static NFT tracer, which otherwise
-  // sees `path.join(process.cwd(), ...)` as a request to trace the entire
-  // project root and pulls 700+ MB of node_modules into the function bundle.
-  // On Vercel, LAMBDA_TASK_ROOT is the function root and is the correct base.
-  const root =
-    process.env.LAMBDA_TASK_ROOT ?? (process as { cwd: () => string })["cwd"]();
-  const binDir = `${root}/bin`;
-  if (process.platform === "linux") {
-    const archBin = `${binDir}/yt-dlp-linux-${process.arch}`;
-    if (existsSync(archBin)) return archBin;
-  }
-  return `${binDir}/${process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp"}`;
+// Turbopack's NFT tracer in Next 16 detects `process.cwd()` and `path.join`
+// as filesystem operations and pulls the entire project root (incl. node_modules,
+// ~700 MB) into the serverless function. Bracket notation and turbopackIgnore
+// comments did not stop it. Hide cwd resolution behind eval — the static
+// analyzer cannot follow strings inside eval. LAMBDA_TASK_ROOT is set on Vercel
+// and avoids the eval branch entirely in production.
+function untracedRoot(): string {
+  if (process.env.LAMBDA_TASK_ROOT) return process.env.LAMBDA_TASK_ROOT;
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-eval
+  return (0, eval)("process.cwd()") as string;
 }
 
-const YT_DLP = resolveBinary();
+let resolvedBin: string | null = null;
+function getBin(): string {
+  if (resolvedBin) return resolvedBin;
+  if (process.env.YT_DLP_PATH) {
+    resolvedBin = process.env.YT_DLP_PATH;
+    return resolvedBin;
+  }
+  const root = untracedRoot();
+  if (process.platform === "linux") {
+    resolvedBin = `${root}/bin/yt-dlp-linux-${process.arch}`;
+  } else if (process.platform === "win32") {
+    resolvedBin = `${root}/bin/yt-dlp.exe`;
+  } else {
+    resolvedBin = `${root}/bin/yt-dlp`;
+  }
+  return resolvedBin;
+}
 
 let ensured = false;
-function ensureExecutable() {
+function ensureExecutable(bin: string) {
   if (ensured || process.platform === "win32") return;
-  if (existsSync(YT_DLP)) {
-    try {
-      chmodSync(YT_DLP, 0o755);
-    } catch {
-      // read-only filesystem on Vercel after cold start is fine; bit stays set from build.
-    }
-  }
   ensured = true;
+  try {
+    chmodSync(bin, 0o755);
+  } catch {
+    // Read-only filesystem on Vercel after cold start; the executable bit
+    // is preserved from build time, so this is fine.
+  }
 }
 
 let cachedCookiesPath: string | null | undefined;
 function resolveCookiesPath(): string | null {
   if (cachedCookiesPath !== undefined) return cachedCookiesPath;
 
-  // Direct path wins.
   const direct = process.env.IG_COOKIES_PATH || process.env.YT_DLP_COOKIES;
   if (direct && existsSync(direct)) {
     cachedCookiesPath = direct;
     return cachedCookiesPath;
   }
 
-  // Inline cookies (Netscape format) via env. Vercel envs survive across invocations
-  // within the same lambda instance — write once to /tmp.
   const inline = process.env.IG_COOKIES_TXT;
   if (inline && inline.trim()) {
-    const target = path.join(os.tmpdir(), "ig-cookies.txt");
+    // /tmp is writable on Vercel and outside the project root, so this
+    // does not trigger over-tracing.
+    const target = "/tmp/ig-cookies.txt";
     try {
       if (!existsSync(target)) {
         writeFileSync(target, inline, { mode: 0o600 });
@@ -77,10 +85,11 @@ const COMMON_ARGS = [
 type YtDlpProcess = ChildProcessByStdio<null, Readable, Readable>;
 
 export function runYtDlp(args: string[]): YtDlpProcess {
-  ensureExecutable();
+  const bin = getBin();
+  ensureExecutable(bin);
   const cookiesPath = resolveCookiesPath();
   const cookieArgs = cookiesPath ? ["--cookies", cookiesPath] : [];
-  return spawn(YT_DLP, [...COMMON_ARGS, ...cookieArgs, ...args], {
+  return spawn(bin, [...COMMON_ARGS, ...cookieArgs, ...args], {
     stdio: ["ignore", "pipe", "pipe"],
   });
 }

--- a/src/lib/yt-dlp.ts
+++ b/src/lib/yt-dlp.ts
@@ -6,7 +6,9 @@ import { existsSync, chmodSync, writeFileSync } from "node:fs";
 
 function resolveBinary(): string {
   if (process.env.YT_DLP_PATH) return process.env.YT_DLP_PATH;
-  const binDir = path.join(process.cwd(), "bin");
+  // turbopackIgnore: keep the tracer from treating cwd-relative joins as a
+  // signal to bundle the entire project root into the serverless function.
+  const binDir = path.join(/* turbopackIgnore: true */ process.cwd(), "bin");
   if (process.platform === "linux") {
     const archBin = path.join(binDir, `yt-dlp-linux-${process.arch}`);
     if (existsSync(archBin)) return archBin;

--- a/src/lib/yt-dlp.ts
+++ b/src/lib/yt-dlp.ts
@@ -6,14 +6,18 @@ import { existsSync, chmodSync, writeFileSync } from "node:fs";
 
 function resolveBinary(): string {
   if (process.env.YT_DLP_PATH) return process.env.YT_DLP_PATH;
-  // turbopackIgnore: keep the tracer from treating cwd-relative joins as a
-  // signal to bundle the entire project root into the serverless function.
-  const binDir = path.join(/* turbopackIgnore: true */ process.cwd(), "bin");
+  // Bracket-notation defeats Turbopack's static NFT tracer, which otherwise
+  // sees `path.join(process.cwd(), ...)` as a request to trace the entire
+  // project root and pulls 700+ MB of node_modules into the function bundle.
+  // On Vercel, LAMBDA_TASK_ROOT is the function root and is the correct base.
+  const root =
+    process.env.LAMBDA_TASK_ROOT ?? (process as { cwd: () => string })["cwd"]();
+  const binDir = `${root}/bin`;
   if (process.platform === "linux") {
-    const archBin = path.join(binDir, `yt-dlp-linux-${process.arch}`);
+    const archBin = `${binDir}/yt-dlp-linux-${process.arch}`;
     if (existsSync(archBin)) return archBin;
   }
-  return path.join(binDir, process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp");
+  return `${binDir}/${process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp"}`;
 }
 
 const YT_DLP = resolveBinary();

--- a/src/lib/yt-dlp.ts
+++ b/src/lib/yt-dlp.ts
@@ -1,0 +1,125 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import path from "node:path";
+import os from "node:os";
+import { existsSync, chmodSync, writeFileSync } from "node:fs";
+
+function resolveBinary(): string {
+  if (process.env.YT_DLP_PATH) return process.env.YT_DLP_PATH;
+  const binDir = path.join(process.cwd(), "bin");
+  if (process.platform === "linux") {
+    const archBin = path.join(binDir, `yt-dlp-linux-${process.arch}`);
+    if (existsSync(archBin)) return archBin;
+  }
+  return path.join(binDir, process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp");
+}
+
+const YT_DLP = resolveBinary();
+
+let ensured = false;
+function ensureExecutable() {
+  if (ensured || process.platform === "win32") return;
+  if (existsSync(YT_DLP)) {
+    try {
+      chmodSync(YT_DLP, 0o755);
+    } catch {
+      // read-only filesystem on Vercel after cold start is fine; bit stays set from build.
+    }
+  }
+  ensured = true;
+}
+
+let cachedCookiesPath: string | null | undefined;
+function resolveCookiesPath(): string | null {
+  if (cachedCookiesPath !== undefined) return cachedCookiesPath;
+
+  // Direct path wins.
+  const direct = process.env.IG_COOKIES_PATH || process.env.YT_DLP_COOKIES;
+  if (direct && existsSync(direct)) {
+    cachedCookiesPath = direct;
+    return cachedCookiesPath;
+  }
+
+  // Inline cookies (Netscape format) via env. Vercel envs survive across invocations
+  // within the same lambda instance — write once to /tmp.
+  const inline = process.env.IG_COOKIES_TXT;
+  if (inline && inline.trim()) {
+    const target = path.join(os.tmpdir(), "ig-cookies.txt");
+    try {
+      if (!existsSync(target)) {
+        writeFileSync(target, inline, { mode: 0o600 });
+      }
+      cachedCookiesPath = target;
+      return cachedCookiesPath;
+    } catch {
+      cachedCookiesPath = null;
+      return cachedCookiesPath;
+    }
+  }
+
+  cachedCookiesPath = null;
+  return cachedCookiesPath;
+}
+
+const COMMON_ARGS = [
+  "--no-playlist",
+  "--no-warnings",
+  "--no-cache-dir",
+  "--no-progress",
+];
+
+type YtDlpProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+export function runYtDlp(args: string[]): YtDlpProcess {
+  ensureExecutable();
+  const cookiesPath = resolveCookiesPath();
+  const cookieArgs = cookiesPath ? ["--cookies", cookiesPath] : [];
+  return spawn(YT_DLP, [...COMMON_ARGS, ...cookieArgs, ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function hasCookies(): boolean {
+  return resolveCookiesPath() !== null;
+}
+
+export async function getInfo(url: string) {
+  const proc = runYtDlp(["--dump-single-json", url]);
+  const chunks: Buffer[] = [];
+  let stderr = "";
+  proc.stdout.on("data", (c) => chunks.push(c));
+  proc.stderr.on("data", (c) => (stderr += c.toString()));
+  const code: number = await new Promise((resolve) =>
+    proc.on("close", (c) => resolve(c ?? 1)),
+  );
+  if (code !== 0) {
+    throw new Error(stderr.trim() || `yt-dlp exited with ${code}`);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+export function streamYtDlp(args: string[]) {
+  const proc = runYtDlp([...args, "-o", "-"]);
+  let stderr = "";
+  proc.stderr.on("data", (c) => (stderr += c.toString()));
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      proc.stdout.on("data", (chunk: Buffer) => controller.enqueue(chunk));
+      proc.stdout.on("end", () => controller.close());
+      proc.on("error", (err) => controller.error(err));
+      proc.on("close", (code) => {
+        if (code !== 0) {
+          try {
+            controller.error(new Error(stderr.trim() || `yt-dlp exited with ${code}`));
+          } catch {
+            // controller already closed
+          }
+        }
+      });
+    },
+    cancel() {
+      proc.kill("SIGTERM");
+    },
+  });
+  return stream;
+}

--- a/src/workers/whisper-worker.ts
+++ b/src/workers/whisper-worker.ts
@@ -1,0 +1,70 @@
+/// <reference lib="webworker" />
+
+import { pipeline, type PipelineType } from "@huggingface/transformers";
+
+type InitMsg = {
+  type: "init";
+  model: string;
+  dtype: unknown;
+  device: "wasm" | "webgpu" | "cpu" | "auto";
+};
+
+type TranscribeMsg = {
+  type: "transcribe";
+  audio: Float32Array;
+  options?: {
+    chunk_length_s?: number;
+    stride_length_s?: number;
+    return_timestamps?: boolean;
+  };
+};
+
+type InMsg = InitMsg | TranscribeMsg;
+
+type Transcriber = (
+  input: Float32Array,
+  opts?: TranscribeMsg["options"],
+) => Promise<{ text: string; chunks?: unknown[] }>;
+
+let transcriber: Transcriber | null = null;
+
+self.addEventListener("message", async (e: MessageEvent<InMsg>) => {
+  const msg = e.data;
+  try {
+    if (msg.type === "init") {
+      transcriber = (await pipeline(
+        "automatic-speech-recognition" as PipelineType,
+        msg.model,
+        {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          dtype: msg.dtype as any,
+          device: msg.device,
+          progress_callback: (p: {
+            status: string;
+            loaded?: number;
+            total?: number;
+            progress?: number;
+            file?: string;
+          }) => {
+            self.postMessage({ type: "progress", payload: p });
+          },
+        },
+      )) as unknown as Transcriber;
+      self.postMessage({ type: "ready" });
+      return;
+    }
+
+    if (msg.type === "transcribe") {
+      if (!transcriber) {
+        self.postMessage({ type: "error", message: "Model not loaded" });
+        return;
+      }
+      const result = await transcriber(msg.audio, msg.options);
+      self.postMessage({ type: "result", payload: result });
+      return;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    self.postMessage({ type: "error", message });
+  }
+});


### PR DESCRIPTION
Migrate three standalone projects into a unified /tools namespace with the portfolio's editorial design language:

  /tools                  index with row-style listing + SVG glyphs
  /tools/speech-to-text   in-browser Whisper mic transcription
  /tools/instagram        reel downloader + transcript (yt-dlp + Whisper)
  /tools/img-grid         client-side image grid composer

Whisper inference runs in a Web Worker (src/workers/whisper-worker.ts) to keep the UI responsive. yt-dlp is spawned server-side with argv (no shell), URLs validated by regex, and IP-keyed sliding-window rate limiting via Upstash. Image proxy at /api/instagram/thumb has a strict host allowlist (cdninstagram, fbcdn, instagram) and forces https.

Security:
  * bump next 16.0.10 -> 16.2.4 (closes GHSA-h25m-26qc-wcjf high DoS, GHSA-5f7q-jpqc-wp7h PPR memory)
  * new src/lib/jsonld.ts safeJsonLd() escapes "<" so JSON-LD payloads can't break out of <script>; applied in layout.tsx and blog/[slug]
  * .gitignore now excludes /bin/yt-dlp* (downloaded by postinstall)

Other:
  * SlideTabs: drop Contact, add Tools
  * Home experience: add SAS Institute (Apr 2026 - present), update Coalition end date to April 2026