### PR TITLE
fix(photography): mobile responsiveness — overflow, tile sizing, lightbox

### DIFF
--- a/apps/web/src/components/PhotographyGallery.tsx
+++ b/apps/web/src/components/PhotographyGallery.tsx
@@ -58,9 +58,15 @@ export default function PhotographyGallery({ photos }: { photos: Photo[] }) {
   // 1200px, and the first client render must match it exactly.
   const [windowWidth, setWindowWidth] = useState<number>(1200);
 
+  // documentElement.clientWidth, not window.innerWidth: when the server-rendered
+  // 1200px grid overflows a phone, mobile Chrome reports the overflowed width
+  // through innerWidth — laying out against it keeps the page permanently wider
+  // than the screen. clientWidth stays pinned to the real layout viewport.
+  const viewportWidth = () => document.documentElement.clientWidth;
+
   // Measure before first paint so narrow screens never flash the 1200px layout.
   useIsomorphicLayoutEffect(() => {
-    setWindowWidth(window.innerWidth);
+    setWindowWidth(viewportWidth());
   }, []);
 
   // Debounce resize: re-laying out the whole grid on every pixel of a drag
@@ -69,7 +75,7 @@ export default function PhotographyGallery({ photos }: { photos: Photo[] }) {
     let timer: ReturnType<typeof setTimeout>;
     const handleResize = () => {
       clearTimeout(timer);
-      timer = setTimeout(() => setWindowWidth(window.innerWidth), 100);
+      timer = setTimeout(() => setWindowWidth(viewportWidth()), 100);
     };
     window.addEventListener("resize", handleResize);
     return () => {
@@ -294,22 +300,20 @@ export default function PhotographyGallery({ photos }: { photos: Photo[] }) {
                   display: "flex",
                   gap: "4px",
                   marginBottom: "4px",
-                  justifyContent: "center",
                 }}
               >
                 {row.map((photo) => {
                   const { aspectRatio } = dimsFor(photo);
 
-                  const isSingleImage = row.length === 1;
-                  let imageWidth, imageHeight;
-
-                  if (isSingleImage) {
-                    imageWidth = availableWidth;
-                    imageHeight = imageWidth / aspectRatio;
-                  } else {
-                    imageHeight = rowHeight;
-                    imageWidth = imageHeight * aspectRatio;
-                  }
+                  // Pixel width is only an estimate for the `sizes` hint; the
+                  // rendered width is a percentage of the row (proportional to
+                  // aspect ratio) so the grid always fits its container —
+                  // including the pre-hydration paint where the server's
+                  // 1200px grouping renders on a narrow phone.
+                  const imageWidth =
+                    row.length === 1
+                      ? availableWidth
+                      : rowHeight * aspectRatio;
 
                   return (
                     <div
@@ -317,8 +321,10 @@ export default function PhotographyGallery({ photos }: { photos: Photo[] }) {
                       onClick={(e) => openLightbox(photo, e.currentTarget)}
                       onMouseEnter={() => preloadLightbox(photo)}
                       style={{
-                        width: imageWidth,
-                        height: imageHeight,
+                        width: `calc((100% - ${gapTotal}px) * ${
+                          aspectRatio / totalAspectRatio
+                        })`,
+                        aspectRatio: `${aspectRatio}`,
                         flexShrink: 0,
                         cursor: "pointer",
                         position: "relative",


### PR DESCRIPTION
## Problem

On phones the photography page scrolled sideways permanently: a 390px viewport ended up with a 549px-wide layout, tiles up to 451px wide, and a 517px lightbox image.

Root cause is a feedback loop:
1. The server renders the grid deterministically at 1200px (required for hydration).
2. That content overflows a phone on first paint, and mobile Chrome then reports the *overflowed* width through `window.innerWidth` (549px instead of 390px).
3. The grid re-lays out against 549px → content stays 549px wide → the overflow sustains itself.

## Fix

- Measure `document.documentElement.clientWidth` instead of `window.innerWidth` — it stays pinned to the real layout viewport regardless of content overflow.
- Tile widths are now percentages of the row (proportional to aspect ratio, with CSS `aspect-ratio` deriving height) instead of fixed pixels, so the grid fits **any** container width — including the pre-hydration paint where the server's 1200px grouping briefly renders on a narrow phone. (Tried flex-grow first, but `align-items: stretch` + `aspect-ratio` lets the cross size drive the width — percentages are deterministic.)
- Pixel math is kept only as the estimate for the `next/image` `sizes` hint.

## Verification (puppeteer, production build)

| Viewport | Before | After |
|---|---|---|
| 390×844 (iPhone) | 159px horizontal overflow, 2-up rows, tiles 451px | 0 overflow, single column, tiles 358px (full width) |
| 390 lightbox | image 517px wide (off-screen) | image 358px, close button on-screen |
| 768 / 1024 | — | 0 overflow, 2-up / 3-up rows |
| 1440 light+dark | baseline | **0.000% pixel diff** vs main |

No hydration warnings or console errors in any pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)