### PR TITLE
feat(design-system): status system + tags/cards/tables/charts (0.3.0)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -536,6 +536,56 @@ Monospace, 0.7rem, uppercase, underline = `1px solid var(--border-light)` that d
 
 ---
 
+## System Layer — Status, Tags, Cards, Charts
+
+`packages/design-system/src/system.css` is a shared layer imported by both
+`tokens.css` (portfolio) and `shadcn.css` (shadcn consumers like thestockie),
+so every app gets the same status vocabulary.
+
+### Status colors
+
+Semantic tokens, theme-adaptive: the **text** shade darkens in light and
+brightens in dark; **surfaces/borders** are translucent `color-mix` tints that
+read on both cream and warm-black.
+
+| Tone       | Light text | Dark text  | Utilities                                                 |
+| ---------- | ---------- | ---------- | --------------------------------------------------------- |
+| `positive` | `#15803d`  | `#4ade80`  | `text-positive` · `bg-positive-surface` · `ring-positive` |
+| `negative` | `#b91c1c`  | `#f87171`  | `text-negative` · `bg-negative-surface` · `ring-negative` |
+| `warning`  | `#b45309`  | `#fbbf24`  | `text-warning` · `bg-warning-surface` · `ring-warning`    |
+| `info`     | `#1d4ed8`  | `#60a5fa`  | `text-info` · `bg-info-surface` · `ring-info`             |
+
+`.stat-up` / `.stat-down` are shorthand text colors for numeric deltas.
+
+### Tags
+
+`.tag` + a tone class — mono, uppercase, tinted surface + ring:
+
+```html
+<span class="tag tag-positive">Buy</span>
+<span class="tag tag-strong-negative">Strong Sell</span>
+```
+
+Tones: `tag-positive`, `tag-negative`, `tag-warning`, `tag-info`,
+`tag-neutral`, plus denser `tag-strong-positive` / `tag-strong-negative`.
+Also a React component: `import { Tag } from "@mtosity/design-system"` →
+`<Tag tone="positive">Buy</Tag>`.
+
+### Cards & tables
+
+- `.ds-card` — `--bg-secondary` surface, `--border-light` border, 4px radius.
+  Add `.ds-card-interactive` for a hover that drops the brutalist offset shadow.
+- `.ds-table` — full-width, mono uppercase `<th>`, `--border-light` row rules,
+  `--bg-secondary` row hover.
+
+### Chart palette
+
+Eight distinct, theme-tuned hues exposed as `--color-chart-1..8` (use
+`text-chart-3`, `fill-chart-2`, or `var(--chart-2)` directly). Brighter variants
+apply automatically under `[data-theme="dark"]`.
+
+---
+
 ## Technology Stack
 
 | Layer | Tool |

--- a/apps/web/src/app/blog/hoa-ky-vay-tien/page.tsx
+++ b/apps/web/src/app/blog/hoa-ky-vay-tien/page.tsx
@@ -28,7 +28,7 @@ function BlogContent() {
         Những công cụ này được bán cho các nhà đầu tư trong và ngoài nước, bao gồm cả chính phủ nước ngoài, như một cách để huy động vốn.
       </p>
 
-      <blockquote className="bg-gray-800 border-l-4 border-yellow-500 p-4 my-6 italic">
+      <blockquote className="bg-gray-800 border-l-4 border-warning p-4 my-6 italic">
         <p>Vay nợ ~ phát hành trái phiếu</p>
       </blockquote>
 

--- a/apps/web/src/app/blog/react-performance/page.tsx
+++ b/apps/web/src/app/blog/react-performance/page.tsx
@@ -157,7 +157,7 @@ function BlogContent() {
         />
       </div>
 
-      <p className="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded-lg text-yellow-800 dark:text-yellow-200 mt-4">
+      <p className="bg-warning-surface p-4 rounded-lg text-warning mt-4">
         <strong>The Trap:</strong> Developers often confuse the Render Phase
         with the Commit Phase. React runs your component&apos;s JavaScript logic{" "}
         <em>every time</em> a parent renders—but it only touches the DOM if the
@@ -205,7 +205,7 @@ function BlogContent() {
         <li>
           <strong>The Flamegraph:</strong> Each bar is a component.{" "}
           <span className="text-gray-500">Gray</span> = did not render (good).{" "}
-          <span className="text-yellow-600">Yellow/Red</span> = took time to
+          <span className="text-warning">Yellow/Red</span> = took time to
           render (investigate).
         </li>
         <li>
@@ -400,7 +400,7 @@ function BlogContent() {
         — See how to protect expensive components from unnecessary re-renders.
       </p>
 
-      <p className="bg-red-50 dark:bg-red-900/20 p-4 rounded-lg text-red-800 dark:text-red-200">
+      <p className="bg-negative-surface p-4 rounded-lg text-negative">
         <strong>Warning:</strong> Don&apos;t add React.memo everywhere! It adds
         memory overhead and code complexity. Only use it when the Profiler
         proves you have a problem.
@@ -711,7 +711,7 @@ function BlogContent() {
         — See how to configure browserslist and source maps properly.
       </p>
 
-      <p className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg text-green-800 dark:text-green-200 mt-4">
+      <p className="bg-positive-surface p-4 rounded-lg text-positive mt-4">
         <strong>Real Impact:</strong> Updating browserslist alone can reduce
         your bundle from 450KB to 180KB. That&apos;s a 60% reduction with a
         5-line config change!
@@ -873,7 +873,7 @@ function BlogContent() {
         </li>
       </ul>
 
-      <p className="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded-lg text-yellow-800 dark:text-yellow-200 mt-4">
+      <p className="bg-warning-surface p-4 rounded-lg text-warning mt-4">
         <strong>Best Practice:</strong> Start with framework defaults (Next.js
         auto-prefetches). If using Vite/Webpack, implement route-based splitting
         with TanStack Router. Only manually optimize if profiling shows slow
@@ -953,7 +953,7 @@ function BlogContent() {
         isolate its usage to non-critical paths.
       </p>
 
-      <p className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg text-green-800 dark:text-green-200 mt-6">
+      <p className="bg-positive-surface p-4 rounded-lg text-positive mt-6">
         <strong>Final Thought:</strong> &quot;Building the right thing wrong is
         better than building the wrong thing right... but you can always make
         the right thing <em>righter</em>.&quot;

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mtosity/design-system",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "MTosity design tokens and brutalist UI primitives (warm cream + black + lime).",
   "license": "MIT",
   "repository": {
@@ -21,6 +21,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./tokens.css": "./src/tokens.css",
+    "./shadcn.css": "./src/shadcn.css",
+    "./system.css": "./src/system.css",
     "./styles": "./src/tokens.css"
   },
   "scripts": {

--- a/packages/design-system/src/components/Tag.tsx
+++ b/packages/design-system/src/components/Tag.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+export type TagTone =
+  | "positive"
+  | "negative"
+  | "warning"
+  | "info"
+  | "neutral";
+
+/* Status pill built on the design-system `.tag` utilities (see system.css).
+   <Tag tone="positive">Buy</Tag> · <Tag tone="negative" strong>Strong Sell</Tag>
+   `strong` applies the denser surface (positive/negative only). */
+export const Tag = ({
+  tone = "neutral",
+  strong = false,
+  className,
+  children,
+  ...props
+}: {
+  tone?: TagTone;
+  strong?: boolean;
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLSpanElement>) => {
+  const toneClass =
+    strong && (tone === "positive" || tone === "negative")
+      ? `tag-strong-${tone}`
+      : `tag-${tone}`;
+
+  return (
+    <span
+      className={["tag", toneClass, className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,4 +1,5 @@
 export { SlideTabs } from "./components/SlideTabs";
+export { Tag, type TagTone } from "./components/Tag";
 export { ThemeToggle } from "./components/ThemeToggle";
 export { AccentButton } from "./components/AccentButton";
 export { ConfirmDialog } from "./components/ConfirmDialog";

--- a/packages/design-system/src/shadcn.css
+++ b/packages/design-system/src/shadcn.css
@@ -1,0 +1,162 @@
+/* ──────────────────────────────────────────────────────────────
+   @mtosity/design-system — shadcn/ui bridge
+
+   Drop-in theme for shadcn/ui (Tailwind v4) apps that want the
+   MTosity brutalist-editorial look (warm cream + black + lime).
+
+   Usage (after `@import "tailwindcss"`):
+     @import "@mtosity/design-system/shadcn.css";
+
+   This is SELF-CONTAINED — do NOT also import tokens.css in a shadcn
+   app, or the brand color utilities (bg-accent = lime) will collide
+   with shadcn's accent (a hover surface). This file maps shadcn's
+   semantic tokens onto the palette and ships the heading typography.
+
+   Dark theme: add `data-theme="dark"` to <html> (e.g. next-themes
+   `attribute="data-theme"`). Light is the default.
+   ────────────────────────────────────────────────────────────── */
+
+@import "./system.css";
+
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+/* ── Source palette (runtime CSS vars; flip per theme) ── */
+:root {
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
+    "Liberation Mono", Menlo, monospace;
+
+  color-scheme: light;
+
+  --bg: #f2efe8;
+  --bg-secondary: #e8e5dd;
+  --fg: #0d0d0d;
+  --accent: #bef264;
+  --accent-fg: #0d0d0d;
+  --accent-fg-muted: #3f3e38;
+  --border: #0d0d0d;
+  --border-light: #ccc8bd;
+  --muted: #666460;
+  --danger: #b00020;
+
+  --shadow-brutal: 4px 4px 0 var(--border);
+  --shadow-brutal-lg: 6px 6px 0 var(--border);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #14130f;
+  --bg-secondary: #1e1c17;
+  --fg: #f2efe8;
+  --accent: #bef264;
+  --accent-fg: #0d0d0d;
+  --accent-fg-muted: #3f3e38;
+  --border: #f2efe8;
+  --border-light: #3b3830;
+  --muted: #a5a097;
+  --danger: #f06a7e;
+}
+
+/* ── shadcn semantic tokens → palette ── */
+@theme {
+  --color-background: var(--bg);
+  --color-foreground: var(--fg);
+
+  --color-card: var(--bg-secondary);
+  --color-card-foreground: var(--fg);
+
+  --color-popover: var(--bg-secondary);
+  --color-popover-foreground: var(--fg);
+
+  /* Lime is the primary CTA — ink-on-lime text in both themes */
+  --color-primary: var(--accent);
+  --color-primary-foreground: var(--accent-fg);
+
+  --color-secondary: var(--bg-secondary);
+  --color-secondary-foreground: var(--fg);
+
+  --color-muted: var(--bg-secondary);
+  --color-muted-foreground: var(--muted);
+
+  /* shadcn "accent" = hover/active surface → subtle lime tint */
+  --color-accent: color-mix(in srgb, var(--accent) 16%, transparent);
+  --color-accent-foreground: var(--fg);
+
+  --color-destructive: var(--danger);
+  --color-destructive-foreground: #ffffff;
+
+  --color-border: var(--border-light);
+  --color-input: var(--border-light);
+  --color-ring: var(--accent);
+
+  --color-sidebar: var(--bg-secondary);
+  --color-sidebar-foreground: var(--fg);
+  --color-sidebar-primary: var(--accent);
+  --color-sidebar-primary-foreground: var(--accent-fg);
+  --color-sidebar-accent: color-mix(in srgb, var(--accent) 16%, transparent);
+  --color-sidebar-accent-foreground: var(--fg);
+  --color-sidebar-border: var(--border-light);
+  --color-sidebar-ring: var(--accent);
+
+  /* Chart palette (--color-chart-1..8) + status tokens come from system.css */
+
+  /* Brutalist: near-sharp corners (portfolio uses ~4px on buttons) */
+  --radius-sm: 2px;
+  --radius-md: 3px;
+  --radius-lg: 4px;
+  --radius-xl: 6px;
+
+  /* Fonts — provide --font-inter / --font-crimson-text / --font-lora
+     via next/font in the consuming app's layout. */
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --font-serif: var(--font-lora), Georgia, serif;
+  --font-heading: var(--font-crimson-text), "Crimson Text", Georgia, serif;
+  --font-mono: var(--font-mono);
+}
+
+/* ── Base typography: serif display headings (the editorial signature) ── */
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.015em;
+  }
+  h1 {
+    font-weight: 700;
+    letter-spacing: -0.025em;
+  }
+}
+
+/* ── Shared brutalist utilities ── */
+.chip {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border: 1px solid var(--border-light);
+  padding: 0.2rem 0.6rem;
+  display: inline-block;
+}
+
+.shadow-brutal {
+  box-shadow: var(--shadow-brutal);
+}
+
+.shadow-brutal-lg {
+  box-shadow: var(--shadow-brutal-lg);
+}
+
+.link-hover {
+  color: var(--muted);
+  transition: color 0.15s;
+}
+.link-hover:hover {
+  color: var(--fg);
+}

--- a/packages/design-system/src/system.css
+++ b/packages/design-system/src/system.css
@@ -1,0 +1,194 @@
+/* ──────────────────────────────────────────────────────────────
+   @mtosity/design-system — shared system layer
+
+   Status colors, tags, cards, tables, and the chart palette. Imported
+   by both tokens.css and shadcn.css, so every consuming app gets them.
+
+   Theme-adaptive via [data-theme="dark"]. Status TEXT uses a darker
+   shade in light and a brighter one in dark; SURFACES/borders use
+   translucent tints (color-mix) so they read on both the cream and
+   warm-black backgrounds without per-theme overrides.
+   ────────────────────────────────────────────────────────────── */
+
+:root {
+  /* Semantic status — readable text on the light (cream) background */
+  --positive: #15803d; /* green-700 */
+  --negative: #b91c1c; /* red-700   */
+  --warning: #b45309; /* amber-700 */
+  --info: #1d4ed8; /* blue-700  */
+
+  /* Translucent surfaces + borders (work on both themes) */
+  --positive-surface: color-mix(in srgb, #22c55e 14%, transparent);
+  --positive-surface-strong: color-mix(in srgb, #22c55e 22%, transparent);
+  --positive-border: color-mix(in srgb, #22c55e 38%, transparent);
+  --negative-surface: color-mix(in srgb, #ef4444 14%, transparent);
+  --negative-surface-strong: color-mix(in srgb, #ef4444 22%, transparent);
+  --negative-border: color-mix(in srgb, #ef4444 38%, transparent);
+  --warning-surface: color-mix(in srgb, #f59e0b 16%, transparent);
+  --warning-surface-strong: color-mix(in srgb, #f59e0b 24%, transparent);
+  --warning-border: color-mix(in srgb, #f59e0b 40%, transparent);
+  --info-surface: color-mix(in srgb, #3b82f6 14%, transparent);
+  --info-border: color-mix(in srgb, #3b82f6 38%, transparent);
+
+  /* Chart palette — distinct + legible on the cream background */
+  --chart-1: #84cc16; /* lime   */
+  --chart-2: #0ea5e9; /* sky    */
+  --chart-3: #f59e0b; /* amber  */
+  --chart-4: #ec4899; /* pink   */
+  --chart-5: #8b5cf6; /* violet */
+  --chart-6: #14b8a6; /* teal   */
+  --chart-7: #f97316; /* orange */
+  --chart-8: #64748b; /* slate  */
+}
+
+[data-theme="dark"] {
+  --positive: #4ade80; /* green-400 */
+  --negative: #f87171; /* red-400   */
+  --warning: #fbbf24; /* amber-400 */
+  --info: #60a5fa; /* blue-400  */
+
+  /* Brighter chart hues for the warm-black background */
+  --chart-1: #a3e635;
+  --chart-2: #38bdf8;
+  --chart-3: #fbbf24;
+  --chart-4: #f472b6;
+  --chart-5: #a78bfa;
+  --chart-6: #2dd4bf;
+  --chart-7: #fb923c;
+  --chart-8: #94a3b8;
+}
+
+/* Expose as Tailwind utilities: text-positive, bg-negative-surface,
+   ring-warning, text-chart-3, … */
+@theme {
+  --color-positive: var(--positive);
+  --color-positive-surface: var(--positive-surface);
+  --color-negative: var(--negative);
+  --color-negative-surface: var(--negative-surface);
+  --color-warning: var(--warning);
+  --color-warning-surface: var(--warning-surface);
+  --color-info: var(--info);
+  --color-info-surface: var(--info-surface);
+
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-chart-6: var(--chart-6);
+  --color-chart-7: var(--chart-7);
+  --color-chart-8: var(--chart-8);
+}
+
+/* ── Tag / status pill ──
+   Mono uppercase, tinted surface + ring, colored text. Compose a tone:
+   <span class="tag tag-positive">BUY</span> */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  padding: 0.12rem 0.45rem;
+  font-family: var(
+    --font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1.45;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.tag-positive {
+  color: var(--positive);
+  background: var(--positive-surface);
+  border-color: var(--positive-border);
+}
+.tag-negative {
+  color: var(--negative);
+  background: var(--negative-surface);
+  border-color: var(--negative-border);
+}
+.tag-warning {
+  color: var(--warning);
+  background: var(--warning-surface);
+  border-color: var(--warning-border);
+}
+.tag-info {
+  color: var(--info);
+  background: var(--info-surface);
+  border-color: var(--info-border);
+}
+.tag-neutral {
+  color: var(--muted);
+  background: var(--bg-secondary);
+  border-color: var(--border-light);
+}
+.tag-strong-positive {
+  color: var(--positive);
+  background: var(--positive-surface-strong);
+  border-color: var(--positive-border);
+  font-weight: 700;
+}
+.tag-strong-negative {
+  color: var(--negative);
+  background: var(--negative-surface-strong);
+  border-color: var(--negative-border);
+  font-weight: 700;
+}
+
+/* ── Card ── */
+.ds-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  padding: 1rem;
+}
+.ds-card-interactive {
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+}
+.ds-card-interactive:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-brutal, 4px 4px 0 var(--border));
+}
+
+/* ── Table ── */
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.ds-table th {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+.ds-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-light);
+}
+.ds-table tbody tr:hover {
+  background: var(--bg-secondary);
+}
+
+/* ── Numeric deltas ── */
+.stat-up {
+  color: var(--positive);
+}
+.stat-down {
+  color: var(--negative);
+}

--- a/packages/design-system/src/tokens.css
+++ b/packages/design-system/src/tokens.css
@@ -11,6 +11,8 @@
    `static` forces emission even before any utility uses them. */
 /* Make Tailwind's dark: variant follow the theme switch instead of the
    OS preference. */
+@import "./system.css";
+
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme static {


### PR DESCRIPTION
## Summary

Promotes the reusable patterns refined while bringing the design system into **thestockie** back into `@mtosity/design-system`, and adopts them in **mtosity.com**. Also folds in the previously-published `0.2.0` `shadcn.css` (published from a branch but never merged to `main`), so `main` is coherent again.

## Package additions — new `src/system.css` (shared layer)

Imported by **both** `tokens.css` (portfolio) and `shadcn.css` (shadcn apps), so every consumer gets the same vocabulary.

- **Semantic status tokens** — `positive` / `negative` / `warning` / `info`, theme-adaptive: text darkens in light, brightens in dark; surfaces/borders are translucent `color-mix` tints that read on both cream and warm-black. Exposed as `text-positive`, `bg-negative-surface`, `ring-warning`, `.stat-up`/`.stat-down`.
- **Tags** — `.tag` + tone classes (incl. `tag-strong-*`) and a `<Tag>` React component.
- **Cards / tables** — `.ds-card` (+ `.ds-card-interactive` brutalist hover) and `.ds-table` helpers.
- **Chart palette** — `--color-chart-1..8`, brighter under `[data-theme="dark"]` (replaces shadcn.css's 5-color block).
- Bump to **0.3.0**; export `./shadcn.css` + `./system.css`; documented in `DESIGN.md`.

## mtosity.com adoption (low-risk)

Only change: blog callouts (warning/danger/success) now use the status tokens — collapsing the per-element `bg-x-50 dark:bg-x-900/20 text-x-800 dark:text-x-200` pairs into single theme-adaptive classes (`bg-warning-surface text-warning`, etc.). **Visual parity**, no other app changes — the rest of the new surface is purely additive (new classes/tokens nothing currently renders).

## Verification

- ✅ `pnpm build` (turbo) green — all portfolio routes.
- ✅ `@mtosity/design-system` typecheck green.
- After merge, `0.3.0` publishes via the `design-system-v*` tag workflow so thestockie can pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)