### PR TITLE
feat(design-system): brutalist card as the default (.ds-card) — 0.4.0

### DIFF
--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -40,6 +40,12 @@ This exposes:
   `dark:` variant (`@custom-variant`).
 - Shared utility classes: `.chip`, `.link-hover`, `.section-wrapper`,
   `.theme-light-scope`, `.scrollbar-thin`.
+- System layer (status colors, tags, cards, tables, chart palette) via
+  `src/system.css`, imported by both `tokens.css` and `shadcn.css`:
+  - `.tag` (+ `.tag-positive` / `-negative` / `-warning` / `-info` / `-neutral`)
+  - `.ds-card` — the default card: strong theme-adaptive border + hard offset
+    shadow, shown directly. Add `.ds-card-interactive` for a hover lift.
+  - `.ds-table`, and `--color-chart-1..8`.
 
 The lime accent is identical in both themes; only bg/fg/border swap.
 

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mtosity/design-system",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MTosity design tokens and brutalist UI primitives (warm cream + black + lime).",
   "license": "MIT",
   "repository": {

--- a/packages/design-system/src/system.css
+++ b/packages/design-system/src/system.css
@@ -142,22 +142,26 @@
   font-weight: 700;
 }
 
-/* ── Card ── */
+/* ── Card ──
+   Default card chrome is brutalist: a strong (theme-adaptive) border + hard
+   offset shadow, shown directly. `--border` is near-black on light and
+   near-white on dark, so the card lifts off either background. Add
+   `.ds-card-interactive` for a hover lift. */
 .ds-card {
   background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 1rem;
+  box-shadow: var(--shadow-brutal, 4px 4px 0 var(--border));
 }
 .ds-card-interactive {
   transition:
-    border-color 0.15s,
     box-shadow 0.15s,
     transform 0.15s;
 }
 .ds-card-interactive:hover {
-  border-color: var(--border);
-  box-shadow: var(--shadow-brutal, 4px 4px 0 var(--border));
+  transform: translate(-1px, -1px);
+  box-shadow: var(--shadow-brutal-lg, 6px 6px 0 var(--border));
 }
 
 /* ── Table ── */


### PR DESCRIPTION
## What

Make the brutalist card chrome — a strong, theme-adaptive **border + hard offset shadow** — the **default** for `.ds-card`, shown directly rather than only on hover. Requested so consuming apps (thestockie, the alpaca dashboard) can drop their local `strategy-card`-style classes and just use the design-system default.

## Change (`src/system.css`)

```css
.ds-card {
  background: var(--bg-secondary);
  border: 1px solid var(--border);              /* was --border-light */
  border-radius: 4px;
  padding: 1rem;
  box-shadow: var(--shadow-brutal, 4px 4px 0 var(--border));  /* new default */
}
.ds-card-interactive:hover {
  transform: translate(-1px, -1px);             /* new lift */
  box-shadow: var(--shadow-brutal-lg, 6px 6px 0 var(--border));
}
```

`--border` is near-black on light / near-white on dark, so the card lifts off either background. This aligns `.ds-card` with the documented neo-brutalist aesthetic ("1px border + hard offset shadow").

- Bump **0.3.0 → 0.4.0**
- README: document the system layer (`.tag`, `.ds-card`, `.ds-table`)

## Publish

Publishing is gated on pushing a `design-system-v0.4.0` tag (GitHub Actions). Holding that until this merges / you give the go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)