### PR TITLE
feat(web): design-system showcase page at /design-system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,5 @@ Single Vercel project. Root `vercel.json` builds the workspace (`turbo run build
 ## Design Documentation
 
 `DESIGN.md` is the canonical design reference. **Always keep it up to date** when making visual changes — colors, typography, spacing, layout, animations, components, or page structure. Token changes belong in `packages/design-system/src/tokens.css` and the DESIGN.md palette table together.
+
+The rendered showcase lives at `/design-system` (`apps/web/src/app/design-system/`). When you change `@mtosity/design-system` tokens, components, or version, follow `packages/design-system/AGENTS.md` to keep that page in sync.

--- a/apps/web/src/app/design-system/DesignSystemShowcase.tsx
+++ b/apps/web/src/app/design-system/DesignSystemShowcase.tsx
@@ -119,8 +119,7 @@ export function DesignSystemShowcase({
               maxWidth: "16ch",
             }}
           >
-            Design system,{" "}
-            <span style={{ fontStyle: "italic", color: "var(--muted)" }}>one source of truth.</span>
+            Design system.
           </h1>
           <p style={{ marginTop: "1.5rem", fontSize: "1.0625rem", lineHeight: 1.7, color: "var(--muted)", maxWidth: "56ch" }}>
             A living reference for{" "}

--- a/apps/web/src/app/design-system/DesignSystemShowcase.tsx
+++ b/apps/web/src/app/design-system/DesignSystemShowcase.tsx
@@ -100,26 +100,13 @@ export function DesignSystemShowcase({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
         >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "1rem",
-              paddingBottom: "1.25rem",
-              borderBottom: "1px solid var(--border)",
-            }}
+          <span
+            className="tag tag-positive"
+            title="Latest published version"
+            style={{ display: "inline-block", marginBottom: "1.5rem" }}
           >
-            <span style={{ fontFamily: mono, fontSize: "0.75rem", letterSpacing: "0.2em", color: "var(--muted)" }}>
-              00 —
-            </span>
-            <span style={{ fontFamily: mono, fontSize: "0.75rem", fontWeight: 700, letterSpacing: "0.2em" }}>
-              DESIGN SYSTEM
-            </span>
-            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
-            <span className="tag tag-positive" title="Latest published version">
-              v{version}
-            </span>
-          </div>
+            v{version}
+          </span>
 
           <h1
             style={{
@@ -128,11 +115,11 @@ export function DesignSystemShowcase({
               fontWeight: 700,
               lineHeight: 1.05,
               letterSpacing: "-0.025em",
-              margin: "3rem 0 0",
+              margin: 0,
               maxWidth: "16ch",
             }}
           >
-            Tokens &amp; components,{" "}
+            Design system,{" "}
             <span style={{ fontStyle: "italic", color: "var(--muted)" }}>one source of truth.</span>
           </h1>
           <p style={{ marginTop: "1.5rem", fontSize: "1.0625rem", lineHeight: 1.7, color: "var(--muted)", maxWidth: "56ch" }}>
@@ -143,8 +130,18 @@ export function DesignSystemShowcase({
           </p>
         </motion.header>
 
+        {/* ── Installation ── */}
+        <Section num="01" title="Installation">
+          <div className="ds-card" style={{ display: "flex", alignItems: "center", gap: "0.85rem" }}>
+            <span className="tag tag-info">Coming soon</span>
+            <span style={{ color: "var(--muted)", fontSize: "0.95rem" }}>
+              Install + setup instructions are on the way.
+            </span>
+          </div>
+        </Section>
+
         {/* ── Colors ── */}
-        <Section num="01" title="Core palette" subtitle="Swap bg/fg + borders per theme; the lime accent is constant.">
+        <Section num="02" title="Core palette" subtitle="Swap bg/fg + borders per theme; the lime accent is constant.">
           <Grid min={150}>
             {CORE.map((t) => (
               <Swatch key={t.v} {...t} value={resolved[t.v]} />
@@ -153,7 +150,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Status ── */}
-        <Section num="02" title="Status colors" subtitle="Semantic tones for positive / negative / warning / info, plus translucent surfaces.">
+        <Section num="03" title="Status colors" subtitle="Semantic tones for positive / negative / warning / info, plus translucent surfaces.">
           <Grid min={150}>
             {STATUS.map((t) => (
               <Swatch key={t.v} {...t} value={resolved[t.v]} />
@@ -168,7 +165,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Chart palette ── */}
-        <Section num="03" title="Chart palette" subtitle="Eight distinct hues, brightened on dark.">
+        <Section num="04" title="Chart palette" subtitle="Eight distinct hues, brightened on dark.">
           <Grid min={110}>
             {CHART.map((v, i) => (
               <Swatch key={v} v={v} label={`Chart ${i + 1}`} value={resolved[v]} />
@@ -177,7 +174,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Typography ── */}
-        <Section num="04" title="Typography">
+        <Section num="05" title="Typography">
           <div style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
             {FONTS.map((f) => (
               <div key={f.v} className="ds-card">
@@ -193,7 +190,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Shadows ── */}
-        <Section num="05" title="Shadows" subtitle="Hard offset shadows that follow --border, so they adapt per theme.">
+        <Section num="06" title="Shadows" subtitle="Hard offset shadows that follow --border, so they adapt per theme.">
           <Grid min={200}>
             {[
               { v: "--shadow-brutal", label: "Brutal" },
@@ -217,7 +214,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Tags ── */}
-        <Section num="06" title="Tags" subtitle="<Tag tone> pills built on the .tag utilities.">
+        <Section num="07" title="Tags" subtitle="<Tag tone> pills built on the .tag utilities.">
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.6rem", alignItems: "center" }}>
             <Tag tone="positive">Positive</Tag>
             <Tag tone="negative">Negative</Tag>
@@ -230,7 +227,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Cards ── */}
-        <Section num="07" title="Cards" subtitle=".ds-card is brutalist by default (border + offset shadow). Add .ds-card-interactive for a hover lift.">
+        <Section num="08" title="Cards" subtitle=".ds-card is brutalist by default (border + offset shadow). Add .ds-card-interactive for a hover lift.">
           <Grid min={240}>
             <div className="ds-card">
               <div style={{ fontFamily: heading, fontSize: "1.25rem", marginBottom: "0.35rem" }}>
@@ -252,7 +249,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Buttons ── */}
-        <Section num="08" title="Buttons">
+        <Section num="09" title="Buttons">
           <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem", alignItems: "center" }}>
             <AccentButton onClick={() => {}}>Accent</AccentButton>
             <AccentButton shadow onClick={() => {}}>Accent · shadow</AccentButton>
@@ -264,7 +261,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Chips & table ── */}
-        <Section num="09" title="Chips & table">
+        <Section num="10" title="Chips & table">
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginBottom: "2rem" }}>
             <span className="chip">.chip</span>
             <span className="chip">Mono label</span>
@@ -301,7 +298,7 @@ export function DesignSystemShowcase({
         </Section>
 
         {/* ── Components ── */}
-        <Section num="10" title="Components">
+        <Section num="11" title="Components">
           <div style={{ display: "flex", flexDirection: "column", gap: "2rem" }}>
             <ComponentRow label="<ThemeToggle />" note="Stateless, hydration-safe theme switch.">
               <ThemeToggle />

--- a/apps/web/src/app/design-system/DesignSystemShowcase.tsx
+++ b/apps/web/src/app/design-system/DesignSystemShowcase.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  SlideTabs,
+  Tag,
+  AccentButton,
+  StandardButton,
+  OutlineButton,
+  SectionHeader,
+  ConfirmDialog,
+  ThemeToggle,
+  Reveal,
+} from "@mtosity/design-system";
+
+const mono = "var(--font-mono)";
+const heading = "var(--font-heading)";
+
+/* ── Token catalogues ── */
+const CORE: { v: string; label: string }[] = [
+  { v: "--bg", label: "Background" },
+  { v: "--bg-secondary", label: "Surface" },
+  { v: "--fg", label: "Foreground" },
+  { v: "--accent", label: "Accent / lime" },
+  { v: "--accent-fg", label: "Ink on accent" },
+  { v: "--border", label: "Border" },
+  { v: "--border-light", label: "Border · light" },
+  { v: "--muted", label: "Muted" },
+  { v: "--danger", label: "Danger" },
+];
+
+const STATUS: { v: string; label: string }[] = [
+  { v: "--positive", label: "Positive" },
+  { v: "--negative", label: "Negative" },
+  { v: "--warning", label: "Warning" },
+  { v: "--info", label: "Info" },
+];
+
+const SURFACES: { v: string; label: string }[] = [
+  { v: "--positive-surface", label: "Positive · surface" },
+  { v: "--negative-surface", label: "Negative · surface" },
+  { v: "--warning-surface", label: "Warning · surface" },
+  { v: "--info-surface", label: "Info · surface" },
+];
+
+const CHART = Array.from({ length: 8 }, (_, i) => `--chart-${i + 1}`);
+
+const FONTS: { v: string; label: string; sample: string }[] = [
+  { v: "--font-heading", label: "Heading · serif", sample: "Typography is the hero." },
+  { v: "--font-serif", label: "Serif · body", sample: "Editorial, readable long-form." },
+  { v: "--font-sans", label: "Sans · UI", sample: "Clean interface copy and labels." },
+  { v: "--font-mono", label: "Mono · labels", sample: "01 — TOKENS / v0.0.0" },
+];
+
+const ALL_VARS = [...CORE, ...STATUS, ...SURFACES].map((t) => t.v).concat(CHART);
+
+export function DesignSystemShowcase({
+  version,
+  name,
+}: {
+  version: string;
+  name: string;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [resolved, setResolved] = useState<Record<string, string>>({});
+
+  // Resolve every token's computed value, and re-resolve whenever the theme
+  // attribute flips so the displayed hexes always match what's on screen.
+  useEffect(() => {
+    const read = () => {
+      const cs = getComputedStyle(document.documentElement);
+      const next: Record<string, string> = {};
+      for (const v of ALL_VARS) next[v] = cs.getPropertyValue(v).trim();
+      setResolved(next);
+    };
+    read();
+    const obs = new MutationObserver(read);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--fg)" }}>
+      <SlideTabs />
+
+      <main
+        style={{
+          maxWidth: "1100px",
+          margin: "0 auto",
+          padding: "calc(56px + 4rem) clamp(1.5rem, 5vw, 4rem) 6rem",
+        }}
+      >
+        {/* ── Hero ── */}
+        <motion.header
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "1rem",
+              paddingBottom: "1.25rem",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <span style={{ fontFamily: mono, fontSize: "0.75rem", letterSpacing: "0.2em", color: "var(--muted)" }}>
+              00 —
+            </span>
+            <span style={{ fontFamily: mono, fontSize: "0.75rem", fontWeight: 700, letterSpacing: "0.2em" }}>
+              DESIGN SYSTEM
+            </span>
+            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+            <span className="tag tag-positive" title="Latest published version">
+              v{version}
+            </span>
+          </div>
+
+          <h1
+            style={{
+              fontFamily: heading,
+              fontSize: "clamp(2.5rem, 6vw, 4.75rem)",
+              fontWeight: 700,
+              lineHeight: 1.05,
+              letterSpacing: "-0.025em",
+              margin: "3rem 0 0",
+              maxWidth: "16ch",
+            }}
+          >
+            Tokens &amp; components,{" "}
+            <span style={{ fontStyle: "italic", color: "var(--muted)" }}>one source of truth.</span>
+          </h1>
+          <p style={{ marginTop: "1.5rem", fontSize: "1.0625rem", lineHeight: 1.7, color: "var(--muted)", maxWidth: "56ch" }}>
+            A living reference for{" "}
+            <code style={{ fontFamily: mono, fontSize: "0.9em", color: "var(--fg)" }}>{name}</code>{" "}
+            — the warm-cream + black + lime, neo-brutalist system shared across
+            my projects. Flip the theme (top right) to see every token adapt.
+          </p>
+        </motion.header>
+
+        {/* ── Colors ── */}
+        <Section num="01" title="Core palette" subtitle="Swap bg/fg + borders per theme; the lime accent is constant.">
+          <Grid min={150}>
+            {CORE.map((t) => (
+              <Swatch key={t.v} {...t} value={resolved[t.v]} />
+            ))}
+          </Grid>
+        </Section>
+
+        {/* ── Status ── */}
+        <Section num="02" title="Status colors" subtitle="Semantic tones for positive / negative / warning / info, plus translucent surfaces.">
+          <Grid min={150}>
+            {STATUS.map((t) => (
+              <Swatch key={t.v} {...t} value={resolved[t.v]} />
+            ))}
+          </Grid>
+          <div style={{ height: "1.5rem" }} />
+          <Grid min={150}>
+            {SURFACES.map((t) => (
+              <Swatch key={t.v} {...t} value={resolved[t.v]} />
+            ))}
+          </Grid>
+        </Section>
+
+        {/* ── Chart palette ── */}
+        <Section num="03" title="Chart palette" subtitle="Eight distinct hues, brightened on dark.">
+          <Grid min={110}>
+            {CHART.map((v, i) => (
+              <Swatch key={v} v={v} label={`Chart ${i + 1}`} value={resolved[v]} />
+            ))}
+          </Grid>
+        </Section>
+
+        {/* ── Typography ── */}
+        <Section num="04" title="Typography">
+          <div style={{ display: "flex", flexDirection: "column", gap: "1.75rem" }}>
+            {FONTS.map((f) => (
+              <div key={f.v} className="ds-card">
+                <div style={{ fontFamily: mono, fontSize: "0.68rem", letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--muted)", marginBottom: "0.6rem" }}>
+                  {f.label} · {f.v}
+                </div>
+                <div style={{ fontFamily: `var(${f.v})`, fontSize: "1.6rem", lineHeight: 1.3 }}>
+                  {f.sample}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* ── Shadows ── */}
+        <Section num="05" title="Shadows" subtitle="Hard offset shadows that follow --border, so they adapt per theme.">
+          <Grid min={200}>
+            {[
+              { v: "--shadow-brutal", label: "Brutal" },
+              { v: "--shadow-brutal-lg", label: "Brutal · lg" },
+            ].map((s) => (
+              <div key={s.v} style={{ padding: "0.5rem 0.5rem 1.5rem" }}>
+                <div
+                  style={{
+                    height: 90,
+                    background: "var(--bg-secondary)",
+                    border: "1px solid var(--border)",
+                    boxShadow: `var(${s.v})`,
+                  }}
+                />
+                <div style={{ fontFamily: mono, fontSize: "0.68rem", letterSpacing: "0.08em", color: "var(--muted)", marginTop: "1rem" }}>
+                  {s.label} · {s.v}
+                </div>
+              </div>
+            ))}
+          </Grid>
+        </Section>
+
+        {/* ── Tags ── */}
+        <Section num="06" title="Tags" subtitle="<Tag tone> pills built on the .tag utilities.">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "0.6rem", alignItems: "center" }}>
+            <Tag tone="positive">Positive</Tag>
+            <Tag tone="negative">Negative</Tag>
+            <Tag tone="warning">Warning</Tag>
+            <Tag tone="info">Info</Tag>
+            <Tag tone="neutral">Neutral</Tag>
+            <Tag tone="positive" strong>Strong buy</Tag>
+            <Tag tone="negative" strong>Strong sell</Tag>
+          </div>
+        </Section>
+
+        {/* ── Cards ── */}
+        <Section num="07" title="Cards" subtitle=".ds-card is brutalist by default (border + offset shadow). Add .ds-card-interactive for a hover lift.">
+          <Grid min={240}>
+            <div className="ds-card">
+              <div style={{ fontFamily: heading, fontSize: "1.25rem", marginBottom: "0.35rem" }}>
+                .ds-card
+              </div>
+              <p style={{ color: "var(--muted)", fontSize: "0.95rem", lineHeight: 1.6, margin: 0 }}>
+                Default card — strong border + 4px offset shadow, shown directly.
+              </p>
+            </div>
+            <div className="ds-card ds-card-interactive" style={{ cursor: "pointer" }}>
+              <div style={{ fontFamily: heading, fontSize: "1.25rem", marginBottom: "0.35rem" }}>
+                .ds-card-interactive
+              </div>
+              <p style={{ color: "var(--muted)", fontSize: "0.95rem", lineHeight: 1.6, margin: 0 }}>
+                Hover me — lifts with a larger offset shadow.
+              </p>
+            </div>
+          </Grid>
+        </Section>
+
+        {/* ── Buttons ── */}
+        <Section num="08" title="Buttons">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem", alignItems: "center" }}>
+            <AccentButton onClick={() => {}}>Accent</AccentButton>
+            <AccentButton shadow onClick={() => {}}>Accent · shadow</AccentButton>
+            <AccentButton disabled>Disabled</AccentButton>
+            <AccentButton href="#top">As link</AccentButton>
+            <StandardButton>Standard</StandardButton>
+            <OutlineButton>Outline / PDF</OutlineButton>
+          </div>
+        </Section>
+
+        {/* ── Chips & table ── */}
+        <Section num="09" title="Chips & table">
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginBottom: "2rem" }}>
+            <span className="chip">.chip</span>
+            <span className="chip">Mono label</span>
+            <span className="chip">Tag-like</span>
+          </div>
+          <div style={{ overflowX: "auto" }}>
+            <table className="ds-table">
+              <thead>
+                <tr>
+                  <th>Token</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style={{ fontFamily: mono }}>--accent</td>
+                  <td>Primary actions</td>
+                  <td><Tag tone="positive">Stable</Tag></td>
+                </tr>
+                <tr>
+                  <td style={{ fontFamily: mono }}>--shadow-brutal</td>
+                  <td>Card / button lift</td>
+                  <td><Tag tone="info">New</Tag></td>
+                </tr>
+                <tr>
+                  <td style={{ fontFamily: mono }}>--danger</td>
+                  <td>Destructive</td>
+                  <td><Tag tone="warning">Use sparingly</Tag></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        {/* ── Components ── */}
+        <Section num="10" title="Components">
+          <div style={{ display: "flex", flexDirection: "column", gap: "2rem" }}>
+            <ComponentRow label="<ThemeToggle />" note="Stateless, hydration-safe theme switch.">
+              <ThemeToggle />
+            </ComponentRow>
+
+            <ComponentRow label="<SectionHeader />" note="Numbered editorial section title.">
+              <div style={{ width: "100%", maxWidth: 420 }}>
+                <SectionHeader num="04" title="Example" />
+              </div>
+            </ComponentRow>
+
+            <ComponentRow label="<ConfirmDialog />" note="Accessible modal — Esc / Enter handled.">
+              <AccentButton onClick={() => setConfirmOpen(true)}>Open dialog</AccentButton>
+            </ComponentRow>
+
+            <ComponentRow label="<Reveal />" note="Scroll-into-view entrance animation.">
+              <Reveal>
+                <div className="ds-card" style={{ minWidth: 220 }}>
+                  Revealed on scroll ✦
+                </div>
+              </Reveal>
+            </ComponentRow>
+
+            <ComponentRow label="<SlideTabs />" note="The fixed top navigation — shown at the top of this page.">
+              <span style={{ color: "var(--muted)", fontSize: "0.9rem" }}>↑ in use above</span>
+            </ComponentRow>
+          </div>
+        </Section>
+      </main>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Confirm action"
+        message="This is the shared ConfirmDialog from the design system."
+        confirmLabel="Got it"
+        cancelLabel="Close"
+        onConfirm={() => setConfirmOpen(false)}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </div>
+  );
+}
+
+/* ── Local helpers ── */
+
+function Section({
+  num,
+  title,
+  subtitle,
+  children,
+}: {
+  num: string;
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ marginTop: "4.5rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "1rem", paddingBottom: "1rem", borderBottom: "1px solid var(--border)" }}>
+        <span style={{ fontFamily: mono, fontSize: "0.72rem", letterSpacing: "0.2em", color: "var(--muted)" }}>
+          {num} —
+        </span>
+        <span style={{ fontFamily: mono, fontSize: "0.72rem", fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase" }}>
+          {title}
+        </span>
+        <div style={{ flex: 1, height: 1, background: "var(--border-light)" }} />
+      </div>
+      {subtitle && (
+        <p style={{ marginTop: "1rem", color: "var(--muted)", fontSize: "0.95rem", lineHeight: 1.6, maxWidth: "64ch" }}>
+          {subtitle}
+        </p>
+      )}
+      <div style={{ marginTop: "2rem" }}>{children}</div>
+    </section>
+  );
+}
+
+function Grid({ min, children }: { min: number; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(auto-fill, minmax(${min}px, 1fr))`,
+        gap: "1rem",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Swatch({ v, label, value }: { v: string; label: string; value?: string }) {
+  return (
+    <div style={{ border: "1px solid var(--border-light)", background: "var(--bg-secondary)" }}>
+      <div style={{ height: 64, background: `var(${v})`, borderBottom: "1px solid var(--border-light)" }} />
+      <div style={{ padding: "0.6rem 0.7rem" }}>
+        <div style={{ fontSize: "0.85rem", fontWeight: 600 }}>{label}</div>
+        <div style={{ fontFamily: mono, fontSize: "0.68rem", color: "var(--muted)", marginTop: "0.15rem" }}>
+          {v}
+        </div>
+        {value && (
+          <div style={{ fontFamily: mono, fontSize: "0.66rem", color: "var(--muted)", marginTop: "0.1rem" }}>
+            {value}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ComponentRow({
+  label,
+  note,
+  children,
+}: {
+  label: string;
+  note: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: "1.25rem",
+        paddingBottom: "1.5rem",
+        borderBottom: "1px solid var(--border-light)",
+      }}
+    >
+      <div style={{ minWidth: 220, flex: "1 1 220px" }}>
+        <div style={{ fontFamily: mono, fontSize: "0.8rem", fontWeight: 700 }}>{label}</div>
+        <div style={{ color: "var(--muted)", fontSize: "0.85rem", marginTop: "0.3rem" }}>{note}</div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/design-system/DesignSystemShowcase.tsx
+++ b/apps/web/src/app/design-system/DesignSystemShowcase.tsx
@@ -119,7 +119,7 @@ export function DesignSystemShowcase({
               maxWidth: "16ch",
             }}
           >
-            Design system.
+            mtosity&apos;s design system.
           </h1>
           <p style={{ marginTop: "1.5rem", fontSize: "1.0625rem", lineHeight: 1.7, color: "var(--muted)", maxWidth: "56ch" }}>
             A living reference for{" "}

--- a/apps/web/src/app/design-system/page.tsx
+++ b/apps/web/src/app/design-system/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import pkg from "@mtosity/design-system/package.json";
+import { DesignSystemShowcase } from "./DesignSystemShowcase";
+
+export const metadata: Metadata = {
+  title: "Design System",
+  description:
+    "Living reference for @mtosity/design-system — tokens, colors, typography, shadows, and components in the neo-brutalist warm-cream + lime aesthetic.",
+};
+
+export default function DesignSystemPage() {
+  return (
+    <DesignSystemShowcase version={pkg.version} name={pkg.name} />
+  );
+}

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — @mtosity/design-system
+
+Read this before changing anything in this package.
+
+## There is a public showcase page — keep it in sync
+
+The design system is documented at **`/design-system`** in the web app:
+`apps/web/src/app/design-system/` (`page.tsx` + `DesignSystemShowcase.tsx`).
+
+The page is the canonical, rendered reference for tokens + components. It must
+not go stale. The contract:
+
+- **Version** — auto. The page reads the version from this package's
+  `package.json` (`import pkg from "@mtosity/design-system/package.json"`), so a
+  version bump updates the badge with no page edit. (This requires the
+  `"./package.json"` entry in `exports` — keep it.)
+- **Tokens / components — manual.** When you add, rename, or remove any of the
+  following, update the matching catalogue in `DesignSystemShowcase.tsx`:
+  | You changed… | Update in `DesignSystemShowcase.tsx` |
+  |---|---|
+  | a core palette var (`tokens.css`) | `CORE` |
+  | a status color / surface (`system.css`) | `STATUS` / `SURFACES` |
+  | the chart palette (`system.css`) | `CHART` |
+  | a font token (`tokens.css`) | `FONTS` |
+  | a shadow token | the "Shadows" section |
+  | a `.tag` / `.ds-card` / `.ds-table` / `.chip` rule | the relevant section |
+  | a component exported from `index.ts` | add a `<ComponentRow>` |
+
+  New color vars must also be added to `ALL_VARS` so their resolved value shows.
+
+## Releasing
+
+1. Bump `version` in `package.json` (semver).
+2. Merge to `main`.
+3. Push a `design-system-v<version>` tag — the `publish-design-system.yml`
+   GitHub Action publishes to GitHub Packages on that tag. (Versions can't be
+   re-published, so tag only after the bump is on `main`.)
+4. Bump consumers (thestockie, alpaca dashboard, …) to the new `^version` if
+   they need the change.
+
+## Notes
+
+- Tailwind v4, CSS-first. `tokens.css` imports `system.css`; `shadcn.css` is the
+  shadcn bridge and also imports `system.css`. Shadcn apps import `shadcn.css`
+  only (not `tokens.css`).
+- The lime accent is identical in both themes; only bg/fg/border swap via
+  `[data-theme="dark"]`. Brutalist shadows follow `--border`, so they adapt.
+- Keep `DESIGN.md` (repo root) in sync for any visual/token change too.

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -23,7 +23,8 @@
     "./tokens.css": "./src/tokens.css",
     "./shadcn.css": "./src/shadcn.css",
     "./system.css": "./src/system.css",
-    "./styles": "./src/tokens.css"
+    "./styles": "./src/tokens.css",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/design-system/src/components/SlideTabs.tsx
+++ b/packages/design-system/src/components/SlideTabs.tsx
@@ -17,6 +17,7 @@ const NAV_LINKS = [
   { label: "Photos", href: "/photography" },
   { label: "Writing", href: "/blog" },
   { label: "Tools", href: "/tools" },
+  { label: "Design System", href: "/design-system" },
 ];
 
 export const SlideTabs = () => {


### PR DESCRIPTION
## What

A living, rendered reference for `@mtosity/design-system` at **`/design-system`** — shows all tokens and components, with the current version, in both light and dark themes.

## Sections

Core palette · status colors + surfaces · chart palette · typography · shadows · tags · cards (`.ds-card` default + interactive) · buttons (Accent/Standard/Outline) · chips & `.ds-table` · components (ThemeToggle, SectionHeader, ConfirmDialog, Reveal, SlideTabs).

## Stays current automatically… and by contract

- **Version badge** reads from the package's `package.json` (added a `"./package.json"` export), so a version bump updates it with no page edit. Currently shows **v0.4.0**.
- **Token values** are resolved live via `getComputedStyle` and re-read on theme toggle, so the hexes always match what's on screen.
- **`packages/design-system/AGENTS.md`** documents the contract: when you add/rename/remove a token or component, update the matching catalogue in `DesignSystemShowcase.tsx`; plus the release steps (bump → merge → push `design-system-v<version>` tag). Pointer added from root `CLAUDE.md`.

## Verification

- `tsc --noEmit` clean for both the design-system package and the web app.
- Lint: only pre-existing warnings elsewhere; nothing new in the added files.
- Rendered locally in light + dark (screenshots shared with author).

> Not wired into the top nav (that's the shared `SlideTabs`) — easy to add a link if you want it discoverable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)